### PR TITLE
Add --crl-file option

### DIFF
--- a/include/sscg.h
+++ b/include/sscg.h
@@ -155,6 +155,7 @@ struct sscg_options
   char *ca_key_file;
   char *cert_file;
   char *cert_key_file;
+  char *crl_file;
 
   /* Overwrite the output files */
   bool overwrite;


### PR DESCRIPTION
... to (optionally) create an empty Certificate Revocation List file.

Default the mode for the file to `0644`, similar to the default for the CA certificate. User can override this with a new `--crl-mode` option.

Closes #10.