### PR TITLE
Add support for generating DH parameter files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
 
 jobs:
   include:
-    - name: "Fedora 29"
-      script: ./.travis/travis-fedora.sh
     - name: "Fedora 30"
+      script: ./.travis/travis-fedora.sh
+    - name: "Fedora 31"
       script: ./.travis/travis-fedora.sh
     - name: "Fedora rawhide"
       script: ./.travis/travis-fedora.sh

--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -5,12 +5,9 @@ set -e
 
 pushd /builddir/
 
-meson --buildtype=debug travis
+meson --buildtype=debug -Dtest_dhparams_4096=true travis
 
-ninja -C travis test
-if [ $? != 0 ]; then
-    cat /builddir/travis/meson-logs/testlog.txt
-fi
+meson test -C travis --verbose
 
 meson --buildtype=debug coverity
 pushd coverity

--- a/include/dhparams.h
+++ b/include/dhparams.h
@@ -1,0 +1,42 @@
+/*
+    This file is part of sscg.
+
+    sscg is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    sscg is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with sscg.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2019 by Stephen Gallagher <sgallagh@redhat.com>
+*/
+
+#ifndef _SSCG_DHPARAMS_H
+#define _SSCG_DHPARAMS_H
+
+#include <talloc.h>
+
+#include "include/sscg.h"
+
+struct sscg_dhparams
+{
+  int prime_len;
+  int generator;
+  DH *dh;
+  BN_GENCB *cb;
+};
+
+int
+create_dhparams (TALLOC_CTX *mem_ctx,
+                 enum sscg_verbosity options,
+                 int prime_len,
+                 int generator,
+                 struct sscg_dhparams **_dhparams);
+
+#endif /* _SSCG_DHPARAMS_H */

--- a/include/sscg.h
+++ b/include/sscg.h
@@ -157,6 +157,11 @@ struct sscg_options
   char *cert_key_file;
   char *crl_file;
 
+  /* Diffie-Hellman Parameters */
+  char *dhparams_file;
+  int dhparams_prime_len;
+  int dhparams_generator;
+
   /* Overwrite the output files */
   bool overwrite;
 };

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,12 @@ endif
 
 has_get_sec_level = cc.has_function(
     'SSL_CTX_get_security_level',
-    dependencies: [ ssl])
+    dependencies: [ ssl ])
+
+has_generator_3 = cc.has_header_symbol(
+    'openssl/dh.h',
+    'DH_GENERATOR_3',
+    dependencies: [ ssl ])
 
 sscg_bin_srcs = [
     'src/sscg.c',
@@ -61,6 +66,7 @@ sscg_bin_srcs = [
 sscg_lib_srcs = [
     'src/authority.c',
     'src/bignum.c',
+    'src/dhparams.c',
     'src/key.c',
     'src/service.c',
     'src/x509.c',
@@ -69,6 +75,7 @@ sscg_lib_srcs = [
 sscg_lib_hdrs = [
     'include/authority.h',
     'include/bignum.h',
+    'include/dhparams.h',
     'include/key.h',
     'include/service.h',
     'include/x509.h',
@@ -149,6 +156,42 @@ init_bignum_test = executable(
     install : false,
 )
 test('init_bignum_test', init_bignum_test)
+
+dhparams_test = executable(
+    'dhparams_test',
+    'test/dhparams_test.c',
+    link_with : sscg_lib,
+    dependencies: [],
+    install : false
+)
+
+# Test generating 512-bit, 1024-bit and 2048-bit DH params with multiple
+# generators. 4096-bit and larger takes over ten minutes, so it's excluded from
+# the test suite by default.
+prime_lengths = [ 512, 1024 ]
+dhparam_timeout = 120
+
+if get_option('run_slow_tests')
+    prime_lengths = prime_lengths + [ 2048, 4096 ]
+    dhparam_timeout = 900
+endif
+
+generators = [ 2, 5 ]
+
+if (has_generator_3)
+    generators += [ 3 ]
+endif
+
+foreach prime_len : prime_lengths
+    foreach g : generators
+        test('dhparams_test_' + prime_len.to_string() + '_' + g.to_string(),
+             dhparams_test,
+             args: [ prime_len.to_string(), g.to_string() ],
+             timeout: dhparam_timeout)
+    endforeach
+endforeach
+
+
 
 cdata = configuration_data()
 cdata.set_quoted('PACKAGE_VERSION', meson.project_version())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,24 @@
+# This file is part of sscg.
+#
+# sscg is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# sscg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with sscg.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 2019 by Stephen Gallagher <sgallagh@redhat.com>
+
+# Generating 4096-bit Diffie-Hellman parameters can take over ten minutes on a
+# fast system. We skip testing it by default.
+
+# Some tests take a long time (dozens of seconds or even minutes)
+# For general development, we will skip them and run them only in the CI
+# environment.
+option('run_slow_tests', type : 'boolean', value : false)

--- a/src/dhparams.c
+++ b/src/dhparams.c
@@ -1,0 +1,146 @@
+/*
+    This file is part of sscg.
+
+    sscg is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    sscg is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with sscg.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2019 by Stephen Gallagher <sgallagh@redhat.com>
+*/
+
+#include <assert.h>
+
+#include "include/sscg.h"
+#include "include/dhparams.h"
+
+
+static int
+_sscg_dhparams_destructor (TALLOC_CTX *ctx);
+
+static int
+dh_cb (int p, int n, BN_GENCB *cb);
+
+int
+create_dhparams (TALLOC_CTX *mem_ctx,
+                 enum sscg_verbosity verbosity,
+                 int prime_len,
+                 int generator,
+                 struct sscg_dhparams **_dhparams)
+{
+  int ret;
+  struct sscg_dhparams *dhparams = NULL;
+  TALLOC_CTX *tmp_ctx = NULL;
+
+  /* First validate the input */
+  assert (_dhparams && !*_dhparams);
+
+  if (prime_len <= 0)
+    {
+      fprintf (stderr, "Prime length must be a positive integer");
+      ret = ERANGE;
+      goto done;
+    }
+
+  if (generator <= 0)
+    {
+      fprintf (stderr, "Generator must be a positive integer");
+      ret = ERANGE;
+      goto done;
+    }
+
+  tmp_ctx = talloc_new (NULL);
+  CHECK_MEM (tmp_ctx);
+
+  dhparams = talloc_zero (tmp_ctx, struct sscg_dhparams);
+  CHECK_MEM (dhparams);
+
+  dhparams->prime_len = prime_len;
+  dhparams->generator = generator;
+  talloc_set_destructor ((TALLOC_CTX *)dhparams, _sscg_dhparams_destructor);
+
+  if (verbosity >= SSCG_DEFAULT)
+    {
+      fprintf (stdout,
+               "Generating DH parameters of length %d and generator %d. "
+               "This will take a long time.\n",
+               dhparams->prime_len,
+               dhparams->generator);
+    }
+
+  dhparams->dh = DH_new ();
+
+  if (verbosity >= SSCG_VERBOSE)
+    {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+      dhparams->cb = talloc_zero (dhparams, BN_GENCB);
+#else
+      dhparams->cb = BN_GENCB_new ();
+#endif
+      if (dhparams->cb == NULL)
+        {
+          ERR_print_errors_fp (stderr);
+          ret = ENOMEM;
+          goto done;
+        }
+
+      BN_GENCB_set (dhparams->cb, dh_cb, NULL);
+    }
+
+  if (!DH_generate_parameters_ex (
+        dhparams->dh, dhparams->prime_len, dhparams->generator, dhparams->cb))
+    {
+      ERR_print_errors_fp (stderr);
+      ret = EIO;
+      goto done;
+    }
+
+  ret = EOK;
+  *_dhparams = talloc_steal (mem_ctx, dhparams);
+
+done:
+  talloc_free (tmp_ctx);
+  return ret;
+}
+
+static int
+_sscg_dhparams_destructor (TALLOC_CTX *ctx)
+{
+  struct sscg_dhparams *params =
+    talloc_get_type_abort (ctx, struct sscg_dhparams);
+
+  if (params->dh != NULL)
+    {
+      DH_free (params->dh);
+      params->dh = NULL;
+    }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+  if (params->cb != NULL)
+    {
+      BN_GENCB_free (params->cb);
+      params->cb = NULL;
+    }
+#endif
+
+  return 0;
+}
+
+static int
+dh_cb (int p, int n, BN_GENCB *cb)
+{
+  static const char symbols[] = ".+*\n";
+  char c = (p >= 0 && (size_t)p < sizeof (symbols) - 1) ? symbols[p] : '?';
+
+  fprintf (stdout, "%c", c);
+
+  return 1;
+}

--- a/test/dhparams_test.c
+++ b/test/dhparams_test.c
@@ -1,0 +1,106 @@
+/*
+    This file is part of sscg.
+
+    sscg is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    sscg is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with sscg.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2019 by Stephen Gallagher <sgallagh@redhat.com>
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <talloc.h>
+#include <openssl/err.h>
+
+#include "include/dhparams.h"
+
+int
+main (int argc, char **argv)
+{
+  int ret, sret, prime_len, generator;
+  struct sscg_dhparams *params = NULL;
+  TALLOC_CTX *main_ctx = NULL;
+
+  if (getenv ("SSCG_SKIP_DHPARAMS"))
+    {
+      /* Skip this test */
+      return 77;
+    }
+
+  errno = 0;
+  prime_len = strtol (argv[1], NULL, 0);
+  if (errno)
+    {
+      fprintf (stderr, "Prime length was not a valid integer.");
+      ret = errno;
+      goto done;
+    }
+
+  errno = 0;
+  generator = strtol (argv[2], NULL, 0);
+  if (errno)
+    {
+      fprintf (stderr, "Generator was not a valid integer.");
+      ret = errno;
+      goto done;
+    }
+
+  main_ctx = talloc_new (NULL);
+
+  ret = create_dhparams (main_ctx, SSCG_DEBUG, prime_len, generator, &params);
+  if (ret != EOK)
+    {
+      fprintf (stderr,
+               "Could not generate DH parameters: [%s]",
+               ERR_error_string (ERR_get_error (), NULL));
+      goto done;
+    }
+
+  if (!DH_check (params->dh, &sret))
+    {
+      ERR_print_errors_fp (stderr);
+      goto done;
+    }
+  if (sret & DH_CHECK_P_NOT_PRIME)
+    fprintf (stderr, "p value is not prime\n");
+  if (sret & DH_CHECK_P_NOT_SAFE_PRIME)
+    fprintf (stderr, "p value is not a safe prime\n");
+  if (sret & DH_CHECK_Q_NOT_PRIME)
+    fprintf (stderr, "q value is not a prime\n");
+  if (sret & DH_CHECK_INVALID_Q_VALUE)
+    fprintf (stderr, "q value is invalid\n");
+  if (sret & DH_CHECK_INVALID_J_VALUE)
+    fprintf (stderr, "j value is invalid\n");
+  if (sret & DH_UNABLE_TO_CHECK_GENERATOR)
+    fprintf (stderr, "unable to check the generator value\n");
+  if (sret & DH_NOT_SUITABLE_GENERATOR)
+    fprintf (stderr, "the g value is not a generator\n");
+
+  if (sret != 0)
+    {
+      /*
+       * We have generated parameters but DH_check() indicates they are
+       * invalid! This should never happen!
+       */
+      fprintf (stderr, "ERROR: Invalid parameters generated\n");
+      ret = EIO;
+      goto done;
+    }
+
+  ret = EOK;
+
+done:
+  talloc_free (main_ctx);
+  return ret;
+}


### PR DESCRIPTION
When generating certificates, it's not uncommon to also want to generate Diffie-Hellman parameters that will be used during the later communication, since that generation is computationally expensive.

These patches add the ability to generate a file storing those parameters while creating the certificates.

This change is related to #13 in that it can be used by FreeRADIUS to replace that portion of its custom [certificate generation script](https://src.fedoraproject.org/rpms/freeradius/blob/93f241adb12b713ee1169dcbed64f2d556eaa00b/f/freeradius-bootstrap-create-only.patch).