### PR TITLE
Fix exponent list in test

### DIFF
--- a/include/sscg.h
+++ b/include/sscg.h
@@ -48,7 +48,7 @@
 #endif
 
 #ifndef discard_const
-#define discard_const(ptr) ((void *)((uintptr_t) (ptr)))
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
 #endif
 
 #ifndef talloc_zfree

--- a/test/generate_rsa_key_test.c
+++ b/test/generate_rsa_key_test.c
@@ -32,7 +32,7 @@ main (int argc, char **argv)
   struct sscg_bignum *e;
   struct sscg_evp_pkey *pkey;
   size_t i, j;
-  unsigned long exp_list[] = { 3, 7, 65537, 0 };
+  unsigned long exp_list[] = { RSA_3, RSA_F4, 0 };
   int bits[] = { 512, 1024, 2048, 4096, 0 };
 
   TALLOC_CTX *tmp_ctx = talloc_new (NULL);


### PR DESCRIPTION
One of the exponents was a typo (7 instead of 17). 17 is no longer
recommended as of OpenSSL 3.0, so drop it and replace the other
exponents with their rsa.h aliases.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>