### PR TITLE
sscg 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
 
           run: |
             CC=${{ matrix.compiler}} meson fedora-${{ matrix.arch }}
-            meson test -t 5 --print-errorlogs -C fedora-${{ matrix.arch }}
+            meson test -t 10 --print-errorlogs -C fedora-${{ matrix.arch }}
 
 
   centos:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,3 +205,54 @@ jobs:
     - name: Run in-tree tests
       run: |
         meson test -t 5 --print-errorlogs -C centos-${{ matrix.release }}
+
+
+  centos-stream:
+    name: CentOS Stream
+    runs-on: ubuntu-latest
+    continue-on-error: false
+
+    strategy:
+      matrix:
+        release:
+          - 9
+        compiler:
+          - gcc
+          - clang
+
+    container:
+      image: quay.io/centos/centos:stream9-development
+
+    steps:
+    - name: Identify the system
+      run: |
+        cat /etc/os-release
+
+    - name: Checkout SSCG code
+      uses: actions/checkout@v2
+
+    - name: Enable CRB
+      run: |
+        yum -y install dnf-plugins-core
+        yum config-manager --set-enabled crb
+
+    - name: Add OpenSSL 3.0 Beta Repo
+      working-directory: /etc/yum.repos.d
+      run: |
+        curl -O https://sgallagh.fedorapeople.org/repo/openssl3b/openssl3b.repo
+
+    - name: Install build dependencies
+      run: |
+        yum install -y meson pkgconf-pkg-config openssl-devel libpath_utils-devel libtalloc-devel help2man popt-devel ${{ matrix.compiler }}
+
+    - name: Configure build directory
+      run: |
+        CC=${{ matrix.compiler}} meson --errorlogs -Drun_slow_tests=false centos-stream-${{ matrix.release }} || ( cat centos-stream-${{ matrix.release }}/meson-logs/meson-log.txt && exit 1 )
+
+    - name: Build SSCG
+      run: |
+        ninja -C centos-stream-${{ matrix.release }}
+
+    - name: Run in-tree tests
+      run: |
+        meson test -t 5 --print-errorlogs -C centos-stream-${{ matrix.release }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Configure build directory
       run: |
-        CC=${{ matrix.compiler}} meson -Drun_slow_tests=true ${{ matrix.os }}
+        CC=${{ matrix.compiler}} meson ${{ matrix.os }}
 
     - name: Build SSCG
       run: |
@@ -99,7 +99,7 @@ jobs:
 
     - name: Configure build directory
       run: |
-        CC=${{ matrix.compiler}} meson -Drun_slow_tests=true fedora-${{ matrix.release }}
+        CC=${{ matrix.compiler}} meson fedora-${{ matrix.release }}
 
     - name: Build SSCG
       run: |
@@ -201,7 +201,7 @@ jobs:
 
     - name: Configure build directory
       run: |
-        CC=${{ matrix.compiler}} meson --errorlogs -Drun_slow_tests=true centos-${{ matrix.release }} || cat centos-7/meson-logs/meson-log.txt
+        CC=${{ matrix.compiler}} meson --errorlogs centos-${{ matrix.release }} || cat centos-7/meson-logs/meson-log.txt
 
     - name: Build SSCG
       run: |
@@ -252,7 +252,7 @@ jobs:
 
     - name: Configure build directory
       run: |
-        CC=${{ matrix.compiler}} meson --errorlogs -Drun_slow_tests=false centos-stream-${{ matrix.release }} || ( cat centos-stream-${{ matrix.release }}/meson-logs/meson-log.txt && exit 1 )
+        CC=${{ matrix.compiler}} meson --errorlogs centos-stream-${{ matrix.release }} || ( cat centos-stream-${{ matrix.release }}/meson-logs/meson-log.txt && exit 1 )
 
     - name: Build SSCG
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,9 +77,9 @@ jobs:
     strategy:
       matrix:
         release:
-          - 32
           - 33
           - 34
+          - 35
         compiler:
           - gcc
           - clang

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,12 @@ jobs:
   ubuntu:
     name: Ubuntu
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+#         https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1936975
+#         - ubuntu-18.04
           - ubuntu-20.04
         compiler:
           - gcc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: uraimo/run-on-arch-action@v2.0.8
+      - uses: uraimo/run-on-arch-action@v2.1.0
         name: Perform upstream tests
 
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,12 @@
 name: Continuous Integration
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   ubuntu:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,9 +190,14 @@ jobs:
         yum -y install dnf-plugins-core
         yum config-manager --set-enabled powertools
 
+    - name: Install OpenSSL 1.1 Development Libraries
+      if: matrix.release == '7'
+      run: |
+        yum -y install openssl11-devel
+
     - name: Install build dependencies
       run: |
-        yum install -y git-core glibc-devel meson pkgconf openssl-devel libpath_utils-devel libtalloc-devel help2man popt-devel ${{ matrix.compiler }}
+        yum install -y git-core glibc-devel openssl-devel meson pkgconf libpath_utils-devel libtalloc-devel help2man popt-devel ${{ matrix.compiler }}
 
     - name: Configure build directory
       run: |

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,11 @@
+# Changes for sscg 3.0
+
+## New features
+* Support for OpenSSL 3.0
+* Support for outputting named Diffie-Hellman parameter groups
+* Support for CentOS Stream 9
+
+## Major version notes
+* SSCG now requires OpenSSL 1.1.0 or later.
+* sscg will now always output DH parameters to a PEM file. It will default to using the `ffdhe4096` group.
+* Generated certificate lifetime now defaults to 398 days, rather than ten years to conform to [modern browser expectations](https://chromium-review.googlesource.com/c/chromium/src/+/2258372).

--- a/README.md
+++ b/README.md
@@ -27,32 +27,65 @@ Usage: sscg [OPTION...]
                                                         private key information to the screen!
   -V, --version                                         Display the version number and exit.
   -f, --force                                           Overwrite any pre-existing files in the requested locations
-      --lifetime=1-3650                                 Certificate lifetime (days). (default: 3650)
+      --lifetime=1-3650                                 Certificate lifetime (days). (default: 398)
       --country=US, CZ, etc.                            Certificate DN: Country (C). (default: "US")
       --state=Massachusetts, British Columbia, etc.     Certificate DN: State or Province (ST).
       --locality=Westford, Paris, etc.                  Certificate DN: Locality (L).
       --organization=My Company                         Certificate DN: Organization (O). (default: "Unspecified")
       --organizational-unit=Engineering, etc.           Certificate DN: Organizational Unit (OU).
       --email=myname@example.com                        Certificate DN: Email Address (Email).
-      --hostname=server.example.com                     The valid hostname of the certificate. Must be an FQDN. (default: current
-                                                        system FQDN)
-      --subject-alt-name alt.example.com                Optional additional valid hostnames for the certificate. In addition to
-                                                        hostnames, this option also accepts explicit values supported by RFC 5280 such
-                                                        as IP:xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy May be specified multiple times.
+      --hostname=server.example.com                     The valid hostname of the certificate. Must be an FQDN. (default: current system
+                                                        FQDN)
+      --subject-alt-name alt.example.com                Optional additional valid hostnames for the certificate. In addition to hostnames,
+                                                        this option also accepts explicit values supported by RFC 5280 such as
+                                                        IP:xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy May be specified multiple times.
       --package=STRING                                  Unused. Retained for compatibility with earlier versions of sscg.
       --key-strength=2048 or larger                     Strength of the certificate private keys in bits. (default: 2048)
       --hash-alg={sha256,sha384,sha512}                 Hashing algorithm to use for signing. (default: "sha256")
+      --cipher-alg={des-ede3-cbc,aes-256-cbc}           Cipher to use for encrypting key files. (default: "aes-256-cbc")
       --ca-file=STRING                                  Path where the public CA certificate will be stored. (default: "./ca.crt")
-      --ca-mode=0644                                    File mode of the created CA certificate. (default: 0644)
-      --ca-key-file=STRING                              Path where the CA's private key will be stored. If unspecified, the key will
-                                                        be destroyed rather than written to the disk.
-      --ca-key-mode=0600                                File mode of the created CA key. (default: 0600)
-      --cert-file=STRING                                Path where the public service certificate will be stored. (default
-                                                        "./service.pem")
-      --cert-mode=0644                                  File mode of the created certificate. (default: 0644)
-      --cert-key-file=STRING                            Path where the service's private key will be stored. (default
-                                                        "service-key.pem")
-      --cert-key-mode=0600                              File mode of the created certificate key. (default: 0600)
+      --ca-mode=0644                                    File mode of the created CA certificate.
+      --ca-key-file=STRING                              Path where the CA's private key will be stored. If unspecified, the key will be
+                                                        destroyed rather than written to the disk.
+      --ca-key-mode=0600                                File mode of the created CA key.
+      --ca-key-password=STRING                          Provide a password for the CA key file. Note that this will be visible in the
+                                                        process table for all users, so it should be used for testing purposes only. Use
+                                                        --ca-keypassfile or --ca-key-password-prompt for secure password entry.
+      --ca-key-passfile=STRING                          A file containing the password to encrypt the CA key file.
+  -C, --ca-key-password-prompt                          Prompt to enter a password for the CA key file.
+      --crl-file=STRING                                 Path where an (empty) Certificate Revocation List file will be created, for
+                                                        applications that expect such a file to exist. If unspecified, no such file will
+                                                        be created.
+      --crl-mode=0644                                   File mode of the created Certificate Revocation List.
+      --cert-file=STRING                                Path where the public service certificate will be stored. (default "./service.pem")
+      --cert-mode=0644                                  File mode of the created certificate.
+      --cert-key-file=STRING                            Path where the service's private key will be stored. (default "service-key.pem")
+      --cert-key-mode=0600                              File mode of the created certificate key.
+  -p, --cert-key-password=STRING                        Provide a password for the service key file. Note that this will be visible in the
+                                                        process table for all users, so this flag should be used for testing purposes
+                                                        only. Use --cert-keypassfile or --cert-key-password-prompt for secure password
+                                                        entry.
+      --cert-key-passfile=STRING                        A file containing the password to encrypt the service key file.
+  -P, --cert-key-password-prompt                        Prompt to enter a password for the service key file.
+      --client-file=STRING                              Path where a client authentication certificate will be stored.
+      --client-mode=0644                                File mode of the created certificate.
+      --client-key-file=STRING                          Path where the client's private key will be stored. (default is the client-file)
+      --client-key-mode=0600                            File mode of the created certificate key.
+      --client-key-password=STRING                      Provide a password for the client key file. Note that this will be visible in the
+                                                        process table for all users, so this flag should be used for testing purposes
+                                                        only. Use --client-keypassfile or --client-key-password-prompt for secure password
+                                                        entry.
+      --client-key-passfile=STRING                      A file containing the password to encrypt the client key file.
+      --client-key-password-prompt                      Prompt to enter a password for the client key file.
+      --dhparams-file=STRING                            A file to contain a set of Diffie-Hellman parameters. (Default: "./dhparams.pem")
+      --dhparams-named-group=STRING                     Output well-known DH parameters. The available named groups are: ffdhe2048,
+                                                        ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, modp_2048, modp_3072, modp_4096,
+                                                        modp_6144, modp_8192, modp_1536, dh_1024_160, dh_2048_224, dh_2048_256. (Default:
+                                                        "ffdhe4096")
+      --dhparams-prime-len=INT                          The length of the prime number to generate for dhparams, in bits. If set to
+                                                        non-zero, the parameters will be generated rather than using a well-known group.
+                                                        (default: 0)
+      --dhparams-generator={2,3,5}                      The generator value for dhparams. (default: 2)
 
 Help options:
   -?, --help                                            Show this help message

--- a/include/dhparams.h
+++ b/include/dhparams.h
@@ -26,11 +26,17 @@
 #include "include/sscg.h"
 
 
+extern const char *dh_fips_groups[];
+extern const char *dh_nonfips_groups[];
+
+
 int
 create_dhparams (enum sscg_verbosity verbosity,
                  int prime_len,
                  int generator,
                  EVP_PKEY **dhparams);
 
+int
+get_params_by_named_group (const char *group_name, EVP_PKEY **dhparams);
 
 #endif /* _SSCG_DHPARAMS_H */

--- a/include/dhparams.h
+++ b/include/dhparams.h
@@ -36,6 +36,13 @@ create_dhparams (enum sscg_verbosity verbosity,
                  int generator,
                  EVP_PKEY **dhparams);
 
+bool
+is_valid_named_group (const char *group_name);
+
+char *
+valid_dh_group_names (TALLOC_CTX *mem_ctx);
+
+
 int
 get_params_by_named_group (const char *group_name, EVP_PKEY **dhparams);
 

--- a/include/dhparams.h
+++ b/include/dhparams.h
@@ -21,22 +21,16 @@
 #define _SSCG_DHPARAMS_H
 
 #include <talloc.h>
+#include <openssl/evp.h>
 
 #include "include/sscg.h"
 
-struct sscg_dhparams
-{
-  int prime_len;
-  int generator;
-  DH *dh;
-  BN_GENCB *cb;
-};
 
 int
-create_dhparams (TALLOC_CTX *mem_ctx,
-                 enum sscg_verbosity options,
+create_dhparams (enum sscg_verbosity verbosity,
                  int prime_len,
                  int generator,
-                 struct sscg_dhparams **_dhparams);
+                 EVP_PKEY **dhparams);
+
 
 #endif /* _SSCG_DHPARAMS_H */

--- a/include/key.h
+++ b/include/key.h
@@ -21,6 +21,7 @@
 #define _SSCG_KEY_H
 
 #include <openssl/rsa.h>
+#include <openssl/dh.h>
 #include <openssl/evp.h>
 
 #include "include/sscg.h"

--- a/include/key.h
+++ b/include/key.h
@@ -34,7 +34,6 @@ struct sscg_evp_pkey
 int
 sscg_generate_rsa_key (TALLOC_CTX *mem_ctx,
                        int bits,
-                       struct sscg_bignum *e,
                        struct sscg_evp_pkey **_key);
 
 

--- a/include/sscg.h
+++ b/include/sscg.h
@@ -25,6 +25,7 @@
 #define _SSCG_H
 
 #include <errno.h>
+#include <openssl/bn.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/ui.h>
@@ -250,7 +251,35 @@ struct sscg_options
   /* Output Files */
   struct sscg_stream **streams;
 
+  char *ca_file;
+  char *ca_key_file;
+  int ca_mode;
+  int ca_key_mode;
+  char *ca_key_password;
+  char *ca_key_passfile;
+
+  char *cert_file;
+  char *cert_key_file;
+  int cert_mode;
+  int cert_key_mode;
+  char *cert_key_password;
+  char *cert_key_passfile;
+
+  char *client_file;
+  char *client_key_file;
+  int client_mode;
+  int client_key_mode;
+  char *client_key_password;
+  char *client_key_passfile;
+
+  char *crl_file;
+  int crl_mode;
+
+  char *dhparams_file;
+  int dhparams_mode;
+
   /* Diffie-Hellman Parameters */
+  char *dhparams_group;
   int dhparams_prime_len;
   int dhparams_generator;
 
@@ -270,5 +299,12 @@ enum sscg_cert_type
 
 #define SSCG_MIN_KEY_PASS_LEN 4
 #define SSCG_MAX_KEY_PASS_LEN 1023
+
+
+int
+sscg_handle_arguments (TALLOC_CTX *mem_ctx,
+                       int argc,
+                       const char **argv,
+                       struct sscg_options **config);
 
 #endif /* _SSCG_H */

--- a/meson.build
+++ b/meson.build
@@ -175,9 +175,10 @@ init_bignum_test = executable(
 test('init_bignum_test', init_bignum_test)
 
 
-# Test generating 512-bit, 1024-bit and 2048-bit DH params with multiple
-# generators. 4096-bit and larger takes over ten minutes, so it's excluded from
-# the test suite by default.
+# Test generating 512-bit, 1024-bit and 2048-bit and 4096 DH params with
+# multiple generators. 2048-bit and larger takes a long time, so they are
+# excluded from the test suite by default.
+
 prime_lengths = [ 512, 1024 ]
 dhparam_timeout = 120
 
@@ -204,7 +205,6 @@ foreach prime_len : prime_lengths
              timeout: dhparam_timeout)
     endforeach
 endforeach
-
 
 
 cdata = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,7 @@ else
 endif
 
 sscg_bin_srcs = [
+    'src/arguments.c',
     'src/sscg.c',
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('sscg', 'c',
-        version : '2.6.3',
+        version : '3.0.0',
         default_options : [
           'buildtype=debugoptimized',
           'c_std=gnu99',
@@ -33,8 +33,19 @@ foreach cflag: test_cflags
 endforeach
 
 pkg = import('pkgconfig')
-crypto = dependency('libcrypto')
-ssl = dependency('libssl')
+
+crypto = dependency('libcrypto11', version: '>= 1.1.0', required: false)
+if crypto.found()
+else
+    crypto = dependency('libcrypto', version: '>= 1.1.0')
+endif
+
+ssl = dependency('libssl11', version: '>= 1.1.0', required: false)
+if ssl.found()
+else
+    ssl = dependency('libssl', version: '>= 1.1.0')
+endif
+
 path_utils = dependency('path_utils')
 talloc = dependency('talloc')
 
@@ -49,15 +60,6 @@ else
     popt = subproject('popt').get_variable('libpopt_a')
     popt_incdirs = include_directories('subprojects/popt')
 endif
-
-has_get_sec_level = cc.has_function(
-    'SSL_CTX_get_security_level',
-    dependencies: [ ssl ])
-
-has_generator_3 = cc.has_header_symbol(
-    'openssl/dh.h',
-    'DH_GENERATOR_3',
-    dependencies: [ ssl ])
 
 sscg_bin_srcs = [
     'src/sscg.c',
@@ -100,11 +102,13 @@ sscg = executable(
     'sscg',
     sscg_bin_srcs,
     link_with : sscg_lib,
-        dependencies : [
-            path_utils,
-            popt,
-            talloc,
-        ],
+    dependencies : [
+        crypto,
+        path_utils,
+        popt,
+        ssl,
+        talloc,
+    ],
     include_directories : popt_incdirs,
     install : true,
 )
@@ -123,7 +127,7 @@ create_ca_test = executable(
     'create_ca_test',
     'test/create_ca_test.c',
     link_with : sscg_lib,
-        dependencies: [],
+        dependencies: [ crypto ],
     install:false,
 )
 test('create_ca_test', create_ca_test)
@@ -132,7 +136,7 @@ create_csr_test = executable(
     'create_csr_test',
     'test/create_csr_test.c',
     link_with : sscg_lib,
-        dependencies: [],
+        dependencies: [ crypto ],
     install:false,
 )
 test('create_csr_test', create_csr_test)
@@ -141,7 +145,7 @@ generate_rsa_key_test = executable(
     'generate_rsa_key_test',
     'test/generate_rsa_key_test.c',
     link_with : sscg_lib,
-        dependencies: [],
+        dependencies: [ crypto ],
     install:false,
 )
 test('generate_rsa_key_test', generate_rsa_key_test)
@@ -150,7 +154,7 @@ generate_serial_test = executable(
     'generate_serial_test',
     'test/generate_serial_test.c',
     link_with : sscg_lib,
-        dependencies: [],
+        dependencies: [ crypto ],
     install:false,
 )
 test('generate_serial_test', generate_serial_test)
@@ -159,18 +163,11 @@ init_bignum_test = executable(
     'init_bignum_test',
     'test/init_bignum_test.c',
     link_with : sscg_lib,
-        dependencies: [],
+        dependencies: [ crypto ],
     install : false,
 )
 test('init_bignum_test', init_bignum_test)
 
-dhparams_test = executable(
-    'dhparams_test',
-    'test/dhparams_test.c',
-    link_with : sscg_lib,
-    dependencies: [],
-    install : false
-)
 
 # Test generating 512-bit, 1024-bit and 2048-bit DH params with multiple
 # generators. 4096-bit and larger takes over ten minutes, so it's excluded from
@@ -185,9 +182,13 @@ endif
 
 generators = [ 2, 5 ]
 
-if (has_generator_3)
-    generators += [ 3 ]
-endif
+dhparams_test = executable(
+    'dhparams_test',
+    'test/dhparams_test.c',
+    link_with : sscg_lib,
+    dependencies: [ crypto ],
+    install : false
+)
 
 foreach prime_len : prime_lengths
     foreach g : generators
@@ -202,7 +203,6 @@ endforeach
 
 cdata = configuration_data()
 cdata.set_quoted('PACKAGE_VERSION', meson.project_version())
-cdata.set('HAVE_SSL_CTX_GET_SECURITY_LEVEL', has_get_sec_level)
 configure_file(
     output : 'config.h',
     configuration : cdata)

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,11 @@ else
     popt_incdirs = include_directories('subprojects/popt')
 endif
 
+has_evp_rsa_gen = cc.has_header_symbol(
+    'openssl/rsa.h',
+    'EVP_RSA_gen',
+    dependencies: [ crypto ])
+
 sscg_bin_srcs = [
     'src/arguments.c',
     'src/sscg.c',
@@ -204,6 +209,7 @@ endforeach
 
 cdata = configuration_data()
 cdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+cdata.set('HAVE_SSL_EVP_RSA_GEN', has_evp_rsa_gen)
 configure_file(
     output : 'config.h',
     configuration : cdata)

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,10 @@ has_evp_rsa_gen = cc.has_header_symbol(
     'EVP_RSA_gen',
     dependencies: [ crypto ])
 
+has_ossl_param = cc.has_header_symbol(
+    'openssl/core.h',
+    'OSSL_PARAM')
+
 sscg_bin_srcs = [
     'src/arguments.c',
     'src/sscg.c',
@@ -207,9 +211,20 @@ foreach prime_len : prime_lengths
 endforeach
 
 
+named_dhparams_test = executable(
+    'named_dhparams_test',
+    'test/named_dhparams_test.c',
+    link_with : sscg_lib,
+    dependencies: [ crypto ],
+    install : false,
+)
+test('named_dhparams_test', named_dhparams_test, timeout : 60)
+
+
 cdata = configuration_data()
 cdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 cdata.set('HAVE_SSL_EVP_RSA_GEN', has_evp_rsa_gen)
+cdata.set('HAVE_OSSL_PARAM', has_ossl_param)
 configure_file(
     output : 'config.h',
     configuration : cdata)

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -1,0 +1,841 @@
+/*
+    This file is part of sscg.
+
+    sscg is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    sscg is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with sscg.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2021 by Stephen Gallagher <sgallagh@redhat.com>
+*/
+
+#include <path_utils.h>
+#include <popt.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <talloc.h>
+#include <unistd.h>
+
+
+#include "include/sscg.h"
+
+#include "config.h"
+
+#define _GNU_SOURCE
+
+
+void
+print_options (struct sscg_options *opts);
+
+
+static int
+get_security_level (void)
+{
+  SSL_CTX *ssl_ctx = SSL_CTX_new (TLS_method ());
+  int security_level = SSL_CTX_get_security_level (ssl_ctx);
+  SSL_CTX_free (ssl_ctx);
+  ssl_ctx = NULL;
+  return security_level;
+}
+
+
+static int
+set_default_options (struct sscg_options *opts)
+{
+  int security_level = get_security_level ();
+
+  opts->ca_mode = SSCG_CERT_DEFAULT_MODE;
+  opts->ca_key_mode = SSCG_KEY_DEFAULT_MODE;
+
+  opts->cert_mode = SSCG_CERT_DEFAULT_MODE;
+  opts->cert_key_mode = SSCG_KEY_DEFAULT_MODE;
+
+  opts->client_mode = SSCG_CERT_DEFAULT_MODE;
+  opts->client_key_mode = SSCG_KEY_DEFAULT_MODE;
+
+  opts->crl_mode = SSCG_CERT_DEFAULT_MODE;
+
+  opts->dhparams_mode = SSCG_CERT_DEFAULT_MODE;
+
+  opts->lifetime = 3650;
+  opts->dhparams_prime_len = 2048;
+  opts->dhparams_generator = 2;
+
+  /* Select the default key strength based on the system security level
+   * See:
+   * https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_get_security_level.html
+   * for the specification of the minimums.
+   */
+  switch (security_level)
+    {
+    case 0:
+    case 1:
+    case 2:
+      /* Security level 2 and below permits lower key-strengths, but SSCG
+       * will set a minimum of 2048 bits and the sha256 hash algorithm.
+       */
+      opts->hash_alg = talloc_strdup (opts, "sha256");
+      opts->key_strength = 2048;
+      break;
+
+    case 3:
+      opts->hash_alg = talloc_strdup (opts, "sha256");
+      opts->key_strength = 3072;
+      break;
+
+    case 4:
+      opts->hash_alg = talloc_strdup (opts, "sha384");
+      opts->key_strength = 7680;
+      break;
+
+    default:
+      /* Unknown security level. Default to the highest we know about */
+      fprintf (stderr,
+               "Unknown system security level %d. Defaulting to highest-known "
+               "level.\n",
+               security_level);
+      /* Fall through */
+
+    case 5:
+      opts->hash_alg = talloc_strdup (opts, "sha512");
+      opts->key_strength = 15360;
+      break;
+    }
+
+  opts->minimum_key_strength = opts->key_strength;
+
+  opts->cipher_alg = talloc_strdup (opts, "aes-256-cbc");
+
+  return 0;
+}
+
+int
+sscg_handle_arguments (TALLOC_CTX *mem_ctx,
+                       int argc,
+                       const char **argv,
+                       struct sscg_options **config)
+{
+  int ret, sret, opt;
+  poptContext pc;
+  char *minimum_key_strength_help = NULL;
+
+  char *country = NULL;
+  char *state = NULL;
+  char *locality = NULL;
+  char *organization = NULL;
+  char *organizational_unit = NULL;
+  char *email = NULL;
+  char *hostname = NULL;
+  char *packagename;
+  char **alternative_names = NULL;
+
+  TALLOC_CTX *tmp_ctx = talloc_new (NULL);
+  CHECK_MEM (tmp_ctx);
+
+  struct sscg_options *options = talloc_zero (tmp_ctx, struct sscg_options);
+  CHECK_MEM (options);
+
+  options->streams =
+    talloc_zero_array (options, struct sscg_stream *, SSCG_NUM_FILE_TYPES);
+
+  ret = set_default_options (options);
+  if (ret != EOK)
+    goto done;
+
+  minimum_key_strength_help =
+    talloc_asprintf (tmp_ctx, "%d or larger", options->minimum_key_strength);
+
+  options->verbosity = SSCG_DEFAULT;
+  // clang-format off
+  struct poptOption long_options[] = {
+    POPT_AUTOHELP
+
+    {
+      "quiet",
+      'q',
+      POPT_ARG_VAL,
+      &options->verbosity,
+      SSCG_QUIET,
+       ("Display no output unless there is an error."),
+      NULL
+    },
+
+    {
+      "verbose",
+      'v',
+      POPT_ARG_VAL,
+      &options->verbosity,
+      SSCG_VERBOSE,
+      _ ("Display progress messages."),
+      NULL
+    },
+
+    {
+      "debug",
+      'd',
+      POPT_ARG_VAL,
+      &options->verbosity,
+      SSCG_DEBUG,
+      _ ("Enable logging of debug messages. Implies verbose. Warning! "
+         "This will print private key information to the screen!"),
+      NULL
+    },
+
+    {
+      "version",
+      'V',
+      POPT_ARG_NONE,
+      &options->print_version,
+      0,
+      _ ("Display the version number and exit."),
+      NULL
+    },
+
+    {
+      "force",
+      'f',
+      POPT_ARG_NONE,
+      &options->overwrite,
+      0,
+      _ ("Overwrite any pre-existing files in the requested locations"),
+      NULL
+    },
+
+    {
+      "lifetime",
+      '\0',
+      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
+      &options->lifetime,
+      0,
+      _ ("Certificate lifetime (days)."),
+      _ ("1-3650")
+    },
+
+    {
+      "country",
+      '\0',
+      POPT_ARG_STRING,
+      &country,
+      0,
+      _ ("Certificate DN: Country (C). (default: \"US\")"),
+      _ ("US, CZ, etc.")
+    },
+
+    {
+      "state",
+      '\0',
+      POPT_ARG_STRING,
+      &state,
+      0,
+      _ ("Certificate DN: State or Province (ST)."),
+      _ ("Massachusetts, British Columbia, etc.")
+    },
+
+    {
+      "locality",
+      '\0',
+      POPT_ARG_STRING,
+      &locality,
+      0,
+      _ ("Certificate DN: Locality (L)."),
+      _ ("Westford, Paris, etc.")
+    },
+
+    {
+      "organization",
+      '\0',
+      POPT_ARG_STRING,
+      &organization,
+      0,
+      _ ("Certificate DN: Organization (O). (default: \"Unspecified\")"),
+      _ ("My Company")
+    },
+
+    {
+      "organizational-unit",
+      '\0',
+      POPT_ARG_STRING,
+      &organizational_unit,
+      0,
+      _ ("Certificate DN: Organizational Unit (OU)."),
+      _ ("Engineering, etc.")
+    },
+
+    {
+      "email",
+      '\0',
+      POPT_ARG_STRING,
+      &email,
+      0,
+      _ ("Certificate DN: Email Address (Email)."),
+      _ ("myname@example.com")
+    },
+
+    {
+      "hostname",
+      '\0',
+      POPT_ARG_STRING,
+      &hostname,
+      0,
+      _ ("The valid hostname of the certificate. Must be an FQDN. (default: "
+         "current system FQDN)"),
+      _ ("server.example.com")
+    },
+
+    {
+      "subject-alt-name",
+      '\0',
+      POPT_ARG_ARGV,
+      &alternative_names,
+      0,
+      _ ("Optional additional valid hostnames for the certificate. "
+         "In addition to hostnames, this option also accepts explicit values "
+         "supported by RFC 5280 such as "
+         "IP:xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy "
+         "May be specified multiple times."),
+      _ ("alt.example.com")
+    },
+
+    {
+      "package",
+      '\0',
+      POPT_ARG_STRING,
+      &packagename,
+      0,
+      _ ("Unused. Retained for compatibility with earlier versions of sscg."),
+      NULL,
+    },
+
+    {
+      "key-strength",
+      '\0',
+      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
+      &options->key_strength,
+      0,
+      _ ("Strength of the certificate private keys in bits."),
+      minimum_key_strength_help },
+    {
+      "hash-alg",
+      '\0',
+      POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT,
+      &options->hash_alg,
+      0,
+      _ ("Hashing algorithm to use for signing."),
+      _ ("{sha256,sha384,sha512}"),
+    },
+
+    {
+      "cipher-alg",
+      '\0',
+      POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT,
+      &options->cipher_alg,
+      0,
+      _ ("Cipher to use for encrypting key files."),
+      _ ("{des-ede3-cbc,aes-256-cbc}"),
+    },
+
+    {
+      "ca-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->ca_file,
+      0,
+      _ ("Path where the public CA certificate will be stored. (default: "
+         "\"./ca.crt\")"),
+      NULL,
+    },
+
+    {
+      "ca-mode",
+      '\0',
+      POPT_ARG_INT,
+      &options->ca_mode,
+      0,
+      _ ("File mode of the created CA certificate."),
+      SSCG_CERT_DEFAULT_MODE_HELP,
+    },
+
+    {
+      "ca-key-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->ca_key_file,
+      0,
+      _ ("Path where the CA's private key will be stored. If unspecified, "
+         "the key will be destroyed rather than written to the disk."),
+      NULL,
+    },
+
+    {
+      "ca-key-mode",
+      '\0',
+      POPT_ARG_INT,
+      &options->ca_key_mode,
+      0,
+      _ ("File mode of the created CA key."),
+      SSCG_KEY_DEFAULT_MODE_HELP,
+    },
+
+    {
+      "ca-key-password",
+      '\0',
+      POPT_ARG_STRING,
+      &options->ca_key_password,
+      0,
+      _ ("Provide a password for the CA key file. Note that this will be "
+         "visible in the process table for all users, so it should be used "
+         "for testing purposes only. Use --ca-keypassfile or "
+         "--ca-key-password-prompt for secure password entry."),
+      NULL
+    },
+
+    {
+      "ca-key-passfile",
+      '\0',
+      POPT_ARG_STRING,
+      &options->ca_key_passfile,
+      0,
+      _ ("A file containing the password to encrypt the CA key file."),
+      NULL
+    },
+
+    {
+      "ca-key-password-prompt",
+      'C',
+      POPT_ARG_NONE,
+      &options->ca_key_pass_prompt,
+      0,
+      _ ("Prompt to enter a password for the CA key file."),
+      NULL
+    },
+
+    {
+      "crl-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->crl_file,
+      0,
+      _ ("Path where an (empty) Certificate Revocation List file will be "
+         "created, for applications that expect such a file to exist. If "
+         "unspecified, no such file will be created."),
+      NULL
+    },
+
+    {
+      "crl-mode",
+      '\0',
+      POPT_ARG_INT,
+      &options->crl_mode,
+      0,
+      _ ("File mode of the created Certificate Revocation List."),
+      SSCG_CERT_DEFAULT_MODE_HELP,
+    },
+
+    {
+      "cert-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->cert_file,
+      0,
+      _ ("Path where the public service certificate will be stored. "
+         "(default \"./service.pem\")"),
+      NULL,
+    },
+
+    {
+      "cert-mode",
+      '\0',
+      POPT_ARG_INT,
+      &options->cert_mode,
+      0,
+      _ ("File mode of the created certificate."),
+      SSCG_CERT_DEFAULT_MODE_HELP,
+    },
+
+    {
+      "cert-key-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->cert_key_file,
+      0,
+      _ ("Path where the service's private key will be stored. "
+         "(default \"service-key.pem\")"),
+      NULL,
+    },
+
+    {
+      "cert-key-mode",
+      '\0',
+      POPT_ARG_INT,
+      &options->cert_key_mode,
+      0,
+      _ ("File mode of the created certificate key."),
+      SSCG_KEY_DEFAULT_MODE_HELP,
+    },
+
+    {
+      "cert-key-password",
+      'p',
+      POPT_ARG_STRING,
+      &options->cert_key_password,
+      0,
+      _ ("Provide a password for the service key file. Note that this will be "
+         "visible in the process table for all users, so this flag should be "
+         "used for testing purposes only. Use --cert-keypassfile or "
+         "--cert-key-password-prompt for secure password entry."),
+      NULL
+    },
+
+    {
+      "cert-key-passfile",
+      '\0',
+      POPT_ARG_STRING,
+      &options->cert_key_passfile,
+      0,
+      _ ("A file containing the password to encrypt the service key file."),
+      NULL
+    },
+
+    {
+      "cert-key-password-prompt",
+      'P',
+      POPT_ARG_NONE,
+      &options->cert_key_pass_prompt,
+      0,
+      _ ("Prompt to enter a password for the service key file."),
+      NULL
+    },
+
+    {
+      "client-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->client_file,
+      0,
+      _ ("Path where a client authentication certificate will be stored."),
+      NULL
+    },
+    {
+      "client-mode",
+      '\0',
+      POPT_ARG_INT,
+      &options->client_mode,
+      0,
+      _ ("File mode of the created certificate."),
+      SSCG_CERT_DEFAULT_MODE_HELP,
+    },
+
+    {
+      "client-key-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->client_key_file,
+      0,
+      _ ("Path where the client's private key will be stored. "
+         "(default is the client-file)"),
+      NULL,
+    },
+
+    {
+      "client-key-mode",
+      '\0',
+      POPT_ARG_INT,
+      &options->client_key_mode,
+      0,
+      _ ("File mode of the created certificate key."),
+      SSCG_KEY_DEFAULT_MODE_HELP,
+    },
+
+    {
+      "client-key-password",
+      '\0',
+      POPT_ARG_STRING,
+      &options->client_key_password,
+      0,
+      _ ("Provide a password for the client key file. Note that this will be "
+         "visible in the process table for all users, so this flag should be "
+         "used for testing purposes only. Use --client-keypassfile or "
+         "--client-key-password-prompt for secure password entry."),
+      NULL
+    },
+
+    {
+      "client-key-passfile",
+      '\0',
+      POPT_ARG_STRING,
+      &options->client_key_passfile,
+      0,
+      _ ("A file containing the password to encrypt the client key file."),
+      NULL
+    },
+
+    {
+      "client-key-password-prompt",
+      '\0',
+      POPT_ARG_NONE,
+      &options->client_key_pass_prompt,
+      0,
+      _ ("Prompt to enter a password for the client key file."),
+      NULL
+    },
+
+    {
+      "dhparams-file",
+      '\0',
+      POPT_ARG_STRING,
+      &options->dhparams_file,
+      0,
+      _("A file to contain a set of generated Diffie-Hellman parameters. "
+        "If unspecified, no such file will be created."),
+      NULL
+    },
+
+    {
+      "dhparams-prime-len",
+      '\0',
+      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
+      &options->dhparams_prime_len,
+      0,
+      _ ("The length of the prime number to generate for dhparams, in bits."),
+      NULL
+    },
+
+    {
+      "dhparams-generator",
+      '\0',
+      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
+      &options->dhparams_generator,
+      0,
+      _ ("The generator value for dhparams."),
+      _("{2,3,5}")
+    },
+
+    POPT_TABLEEND
+  };
+  // clang-format on
+
+  pc = poptGetContext (argv[0], argc, argv, long_options, 0);
+  while ((opt = poptGetNextOpt (pc)) != -1)
+    {
+      switch (opt)
+        {
+        default:
+          fprintf (stderr,
+                   "\nInvalid option %s: %s\n\n",
+                   poptBadOption (pc, 0),
+                   poptStrerror (opt));
+          poptPrintUsage (pc, stderr, 0);
+          return 1;
+        }
+    }
+
+  if (options->print_version)
+    {
+      /* Print the version number and exit */
+      printf ("%s\n", PACKAGE_VERSION);
+      exit (0);
+    }
+
+  verbosity = options->verbosity;
+
+  /* Process the Subject information */
+
+  if (country)
+    {
+      if (strlen (country) != 2)
+        {
+          fprintf (stderr, "Country codes must be exactly two letters.\n");
+          ret = EINVAL;
+          goto done;
+        }
+      options->country = talloc_strdup (options, country);
+    }
+  else
+    {
+      /* Country name is mandatory. 1.0 (in Golang) defaulted to
+           "US", so we'll keep it the same to avoid breaking existing
+           usages. */
+      options->country = talloc_strdup (options, "US");
+    }
+  CHECK_MEM (options->country);
+
+  if (state)
+    {
+      options->state = talloc_strdup (options, state);
+    }
+  else
+    {
+      options->state = talloc_strdup (options, "");
+    }
+  CHECK_MEM (options->state);
+
+  if (locality)
+    {
+      options->locality = talloc_strdup (options, locality);
+    }
+  else
+    {
+      options->locality = talloc_strdup (options, "");
+    }
+  CHECK_MEM (options->locality);
+
+  if (organization)
+    {
+      options->org = talloc_strdup (options, organization);
+    }
+  else
+    {
+      /* In 1.0 (Golang), organization defaulted to "Unspecified".
+           Keep it the same here to avoid breaking existing usages. */
+      options->org = talloc_strdup (options, "Unspecified");
+    }
+  CHECK_MEM (options->org);
+
+  if (organizational_unit)
+    {
+      options->org_unit = talloc_strdup (options, organizational_unit);
+    }
+  else
+    {
+      options->org_unit = talloc_strdup (options, "");
+    }
+  CHECK_MEM (options->org_unit);
+
+  if (email)
+    {
+      options->email = talloc_strdup (options, email);
+    }
+  else
+    {
+      options->email = talloc_strdup (options, "");
+    }
+  CHECK_MEM (options->email);
+
+  if (hostname)
+    {
+      options->hostname = talloc_strdup (options, hostname);
+    }
+  else
+    {
+      /* Get hostname from the system */
+      hostname = talloc_zero_array (options, char, HOST_NAME_MAX + 1);
+      CHECK_MEM (hostname);
+
+      sret = gethostname (hostname, HOST_NAME_MAX);
+      if (sret != 0)
+        {
+          ret = errno;
+          goto done;
+        }
+
+      options->hostname = hostname;
+    }
+  CHECK_MEM (options->hostname);
+
+  if (strnlen (options->hostname, MAXHOSTNAMELEN + 1) > MAXHOSTNAMELEN)
+    {
+      fprintf (
+        stderr, "Hostnames may not exceed %d characters\n", MAXHOSTNAMELEN);
+      ret = EINVAL;
+      goto done;
+    }
+
+  /* Use a realloc loop to copy the names from popt into the
+       options struct. It's not the most efficient approach, but
+       it's only done one time, so there is no sense in optimizing
+       it. */
+  if (alternative_names)
+    {
+      size_t i = 0;
+      while (alternative_names[i] != NULL)
+        {
+          options->subject_alt_names = talloc_realloc (
+            options, options->subject_alt_names, char *, i + 2);
+          CHECK_MEM (options->subject_alt_names);
+
+          options->subject_alt_names[i] =
+            talloc_strdup (options->subject_alt_names, alternative_names[i]);
+          CHECK_MEM (options->subject_alt_names[i]);
+
+          /* Add a NULL terminator to the end */
+          options->subject_alt_names[i + 1] = NULL;
+          i++;
+        }
+    }
+
+  if (options->key_strength < options->minimum_key_strength)
+    {
+      fprintf (stderr,
+               "Key strength must be at least %d bits.\n",
+               options->minimum_key_strength);
+      ret = EINVAL;
+      goto done;
+    }
+
+  /* Make sure we have a valid cipher */
+  options->cipher = EVP_get_cipherbyname (options->cipher_alg);
+  if (!options->cipher)
+    {
+      fprintf (stderr, "Invalid cipher specified: %s\n", options->cipher_alg);
+      ret = EINVAL;
+      goto done;
+    }
+
+  /* TODO: restrict this to approved hashes.
+   * For now, we'll only list SHA[256|384|512] in the help */
+  options->hash_fn = EVP_get_digestbyname (options->hash_alg);
+
+  if (!options->hash_fn)
+    {
+      fprintf (stderr, "Unsupported hashing algorithm.");
+      ret = EINVAL;
+      goto done;
+    }
+
+  /* On verbose logging, display all of the selected options. */
+  if (options->verbosity >= SSCG_VERBOSE)
+    print_options (options);
+
+  poptFreeContext (pc);
+
+  *config = talloc_steal (mem_ctx, options);
+
+done:
+  talloc_free (tmp_ctx);
+  return EOK;
+}
+
+
+void
+print_options (struct sscg_options *opts)
+{
+  size_t i = 0;
+  fprintf (stdout, "==== Options ====\n");
+  fprintf (stdout, "Certificate lifetime: %d\n", opts->lifetime);
+  fprintf (stdout, "Country: \"%s\"\n", opts->country);
+  fprintf (stdout, "State or Principality: \"%s\"\n", opts->state);
+  fprintf (stdout, "Locality: \"%s\"\n", opts->locality);
+  fprintf (stdout, "Organization: \"%s\"\n", opts->org);
+  fprintf (stdout, "Organizational Unit: \"%s\"\n", opts->org_unit);
+  fprintf (stdout, "Email Address: \"%s\"\n", opts->email);
+  fprintf (stdout, "Hostname: \"%s\"\n", opts->hostname);
+  if (opts->subject_alt_names)
+    {
+      for (i = 0; opts->subject_alt_names[i]; i++)
+        {
+          fprintf (stdout,
+                   "Subject Alternative Name: \"%s\"\n",
+                   opts->subject_alt_names[i]);
+        }
+    }
+  fprintf (stdout, "=================\n");
+}

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -600,6 +600,18 @@ sscg_handle_arguments (TALLOC_CTX *mem_ctx,
     },
 
     {
+      "dhparams-named-group",
+      '\0',
+      POPT_ARG_STRING,
+      &options->dhparams_group,
+      0,
+      _("Output well-known DH parameters. See "
+        "https://www.openssl.org/docs/manmaster/man7/EVP_KEYMGMT-DH.html "
+        "for details on the available groups."),
+      NULL
+    },
+
+    {
       "dhparams-prime-len",
       '\0',
       POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -68,7 +68,8 @@ set_default_options (struct sscg_options *opts)
 
   opts->lifetime = 398;
 
-  opts->dhparams_prime_len = 2048;
+  opts->dhparams_file = talloc_strdup (opts, "dhparams.pem");
+  opts->dhparams_group = talloc_strdup (opts, "ffdhe4096");
   opts->dhparams_generator = 2;
 
   /* Select the default key strength based on the system security level
@@ -595,8 +596,8 @@ sscg_handle_arguments (TALLOC_CTX *mem_ctx,
       POPT_ARG_STRING,
       &options->dhparams_file,
       0,
-      _("A file to contain a set of generated Diffie-Hellman parameters. "
-        "If unspecified, no such file will be created."),
+      _("A file to contain a set of Diffie-Hellman parameters. "
+        "(Default: \"./dhparams.pem\")"),
       NULL
     },
 
@@ -608,7 +609,7 @@ sscg_handle_arguments (TALLOC_CTX *mem_ctx,
       0,
       _("Output well-known DH parameters. See "
         "https://www.openssl.org/docs/manmaster/man7/EVP_KEYMGMT-DH.html "
-        "for details on the available groups."),
+        "for details on the available groups. (Default: \"ffdhe4096\")"),
       NULL
     },
 
@@ -618,7 +619,9 @@ sscg_handle_arguments (TALLOC_CTX *mem_ctx,
       POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
       &options->dhparams_prime_len,
       0,
-      _ ("The length of the prime number to generate for dhparams, in bits."),
+      _ ("The length of the prime number to generate for dhparams, in bits. "
+         "If set to non-zero, the parameters will be generated rather than "
+         "using a well-known group."),
       NULL
     },
 

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -66,7 +66,8 @@ set_default_options (struct sscg_options *opts)
 
   opts->dhparams_mode = SSCG_CERT_DEFAULT_MODE;
 
-  opts->lifetime = 3650;
+  opts->lifetime = 398;
+
   opts->dhparams_prime_len = 2048;
   opts->dhparams_generator = 2;
 

--- a/src/authority.c
+++ b/src/authority.c
@@ -33,7 +33,6 @@ create_private_CA (TALLOC_CTX *mem_ctx,
   int bits;
   size_t i;
   TALLOC_CTX *tmp_ctx = NULL;
-  struct sscg_bignum *e;
   struct sscg_bignum *serial;
   struct sscg_cert_info *ca_certinfo;
   struct sscg_x509_req *csr;
@@ -137,8 +136,6 @@ create_private_CA (TALLOC_CTX *mem_ctx,
   /* For the private CA, we always use 4096 bits and an exponent
        value of RSA F4 aka 0x10001 (65537) */
   bits = 4096;
-  ret = sscg_init_bignum (tmp_ctx, RSA_F4, &e);
-  CHECK_OK (ret);
 
   /* Generate an RSA keypair for this CA */
   if (options->verbosity >= SSCG_VERBOSE)
@@ -146,7 +143,7 @@ create_private_CA (TALLOC_CTX *mem_ctx,
       fprintf (stdout, "Generating RSA key for private CA.\n");
     }
   /* TODO: support DSA keys as well */
-  ret = sscg_generate_rsa_key (tmp_ctx, bits, e, &pkey);
+  ret = sscg_generate_rsa_key (tmp_ctx, bits, &pkey);
   CHECK_OK (ret);
 
   /* Create a certificate signing request for the private CA */

--- a/src/cert.c
+++ b/src/cert.c
@@ -34,7 +34,6 @@ create_cert (TALLOC_CTX *mem_ctx,
 {
   int ret;
   size_t i;
-  struct sscg_bignum *e;
   struct sscg_bignum *serial;
   struct sscg_cert_info *certinfo;
   struct sscg_x509_req *csr;
@@ -128,17 +127,13 @@ create_cert (TALLOC_CTX *mem_ctx,
   CHECK_MEM (ex);
   sk_X509_EXTENSION_push (certinfo->extensions, ex);
 
-  /* Use an exponent value of RSA F4 aka 0x10001 (65537) */
-  ret = sscg_init_bignum (tmp_ctx, RSA_F4, &e);
-  CHECK_OK (ret);
-
   /* Generate an RSA keypair for this CA */
   if (options->verbosity >= SSCG_VERBOSE)
     {
       fprintf (stdout, "Generating RSA key for certificate.\n");
     }
   /* TODO: support DSA keys as well */
-  ret = sscg_generate_rsa_key (tmp_ctx, options->key_strength, e, &pkey);
+  ret = sscg_generate_rsa_key (tmp_ctx, options->key_strength, &pkey);
   CHECK_OK (ret);
 
   /* Create a certificate signing request for the private CA */

--- a/src/dhparams.c
+++ b/src/dhparams.c
@@ -80,11 +80,7 @@ create_dhparams (TALLOC_CTX *mem_ctx,
 
   if (verbosity >= SSCG_VERBOSE)
     {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-      dhparams->cb = talloc_zero (dhparams, BN_GENCB);
-#else
       dhparams->cb = BN_GENCB_new ();
-#endif
       if (dhparams->cb == NULL)
         {
           ERR_print_errors_fp (stderr);
@@ -123,13 +119,11 @@ _sscg_dhparams_destructor (TALLOC_CTX *ctx)
       params->dh = NULL;
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
   if (params->cb != NULL)
     {
       BN_GENCB_free (params->cb);
       params->cb = NULL;
     }
-#endif
 
   return 0;
 }

--- a/src/dhparams.c
+++ b/src/dhparams.c
@@ -18,6 +18,7 @@
 */
 
 #include <assert.h>
+#include <string.h>
 
 #include <openssl/evp.h>
 
@@ -25,6 +26,45 @@
 #include "include/sscg.h"
 #include "include/dhparams.h"
 
+// clang-format off
+
+#if OPENSSL_VERSION_NUMBER
+const char *dh_fips_groups[] = {
+  "ffdhe2048",
+  "ffdhe3072",
+  "ffdhe4096",
+  "ffdhe6144",
+  "ffdhe8192",
+  NULL,
+};
+
+const char *dh_nonfips_groups[] = {
+  NULL
+};
+#else //OPENSSL_VERSION_NUMBER
+const char *dh_fips_groups[] = {
+  "ffdhe2048",
+  "ffdhe3072",
+  "ffdhe4096",
+  "ffdhe6144",
+  "ffdhe8192",
+  "modp_2048",
+  "modp_3072",
+  "modp_4096",
+  "modp_6144",
+  "modp_8192",
+  NULL,
+};
+
+const char *dh_nonfips_groups[] = {
+  "modp_1536",
+  "dh_1024_160",
+  "dh_2048_224",
+  "dh_2048_256",
+  NULL
+};
+#endif //OPENSSL_VERSION_NUMBER
+// clang-format on
 
 static int
 evp_cb (EVP_PKEY_CTX *ctx);
@@ -137,3 +177,158 @@ evp_cb (EVP_PKEY_CTX *ctx)
 
   return 1;
 }
+
+
+static bool
+is_valid_named_group (const char *group_name)
+{
+  size_t i = 0;
+
+  /* Check FIPS groups */
+  while (dh_fips_groups[i])
+    {
+      if (strcmp (dh_fips_groups[i], group_name) == 0)
+        return true;
+      i++;
+    }
+
+  /* Check non-FIPS groups */
+  if (!FIPS_mode ())
+    {
+      i = 0;
+      while (dh_nonfips_groups[i])
+        {
+          if (strcmp (dh_nonfips_groups[i], group_name) == 0)
+            return true;
+          i++;
+        }
+    }
+
+  return false;
+}
+
+
+#ifdef HAVE_OSSL_PARAM
+int
+get_params_by_named_group (const char *group_name, EVP_PKEY **dhparams)
+{
+  int ret;
+  EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_from_name (NULL, "DH", NULL);
+  OSSL_PARAM ossl_params[2];
+  EVP_PKEY *params = NULL;
+  char *name = NULL;
+
+  if (!is_valid_named_group (group_name))
+    {
+      fprintf (stderr, "Unknown Diffie Hellman finite field group.\n");
+      ret = EINVAL;
+      goto done;
+    }
+
+  name = talloc_strdup (NULL, group_name);
+
+  ossl_params[0] = OSSL_PARAM_construct_utf8_string ("group", name, 0);
+  ossl_params[1] = OSSL_PARAM_construct_end ();
+
+  if (!EVP_PKEY_keygen_init (pctx))
+    {
+      ERR_print_errors_fp (stderr);
+      ret = EIO;
+      goto done;
+    }
+
+  if (!EVP_PKEY_CTX_set_params (pctx, ossl_params))
+    {
+      ERR_print_errors_fp (stderr);
+      ret = EIO;
+      goto done;
+    }
+
+  if (!EVP_PKEY_generate (pctx, &params))
+    {
+      ERR_print_errors_fp (stderr);
+      ret = EIO;
+      goto done;
+    }
+
+  *dhparams = params;
+  params = NULL;
+
+  ret = EOK;
+
+done:
+  EVP_PKEY_free (params);
+  EVP_PKEY_CTX_free (pctx);
+  talloc_free (name);
+  return ret;
+}
+
+#else //HAVE_OSSL_PARAM
+
+static int
+get_group_nid (const char *group_name)
+{
+  if (strcmp ("ffdhe2048", group_name) == 0)
+    {
+      return NID_ffdhe2048;
+    }
+  else if (strcmp ("ffdhe3072", group_name) == 0)
+    {
+      return NID_ffdhe3072;
+    }
+  else if (strcmp ("ffdhe4096", group_name) == 0)
+    {
+      return NID_ffdhe4096;
+    }
+  else if (strcmp ("ffdhe6144", group_name) == 0)
+    {
+      return NID_ffdhe6144;
+    }
+  else if (strcmp ("ffdhe8192", group_name) == 0)
+    {
+      return NID_ffdhe8192;
+    }
+  return NID_undef;
+}
+
+int
+get_params_by_named_group (const char *group_name, EVP_PKEY **dhparams)
+{
+  int ret, sslret;
+  DH *dh = NULL;
+  EVP_PKEY *pkey = NULL;
+
+  if (!is_valid_named_group (group_name))
+    {
+      fprintf (stderr, "Unknown Diffie Hellman finite field group.\n");
+      ret = EINVAL;
+      goto done;
+    }
+
+  dh = DH_new_by_nid (get_group_nid (group_name));
+  if (!dh)
+    {
+      fprintf (stderr, "Could not retrieve DH group %s\n", group_name);
+      ret = EINVAL;
+      goto done;
+    }
+
+  pkey = EVP_PKEY_new ();
+  sslret = EVP_PKEY_assign_DH (pkey, dh);
+  CHECK_SSL (sslret, "EVP_PKEY_ASSIGN_DH");
+
+  /* The dhparams are owned by the pkey now */
+  dh = NULL;
+
+  *dhparams = pkey;
+  pkey = NULL;
+
+  ret = EOK;
+
+done:
+  DH_free (dh);
+  EVP_PKEY_free (pkey);
+  return ret;
+}
+
+#endif //HAVE_OSSL_PARAM

--- a/src/key.c
+++ b/src/key.c
@@ -35,16 +35,21 @@ _sscg_evp_pkey_destructor (TALLOC_CTX *mem_ctx)
 int
 sscg_generate_rsa_key (TALLOC_CTX *mem_ctx,
                        int bits,
-                       struct sscg_bignum *e,
                        struct sscg_evp_pkey **_key)
 {
   int ret, sslret;
   RSA *rsa = NULL;
   EVP_PKEY *pkey = NULL;
+  struct sscg_bignum *e;
+  TALLOC_CTX *tmp_ctx = talloc_new (NULL);
 
   /* Create memory for the actual key */
   rsa = RSA_new ();
   CHECK_MEM (rsa);
+
+  /* Use an exponent value of RSA F4 aka 0x10001 (65537) */
+  ret = sscg_init_bignum (tmp_ctx, RSA_F4, &e);
+  CHECK_OK (ret);
 
   /* Generate a random RSA keypair */
   sslret = RSA_generate_key_ex (rsa, bits, e->bn, NULL);
@@ -75,5 +80,6 @@ sscg_generate_rsa_key (TALLOC_CTX *mem_ctx,
 
 done:
   RSA_free (rsa);
+  talloc_free (tmp_ctx);
   return ret;
 }

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -19,7 +19,6 @@
 
 #define _GNU_SOURCE
 #include <assert.h>
-#include <popt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -39,99 +38,6 @@
 
 
 int verbosity;
-
-
-static int
-get_security_level (void)
-{
-  SSL_CTX *ssl_ctx = SSL_CTX_new (TLS_method ());
-  int security_level = SSL_CTX_get_security_level (ssl_ctx);
-  SSL_CTX_free (ssl_ctx);
-  ssl_ctx = NULL;
-  return security_level;
-}
-
-static int
-set_default_options (struct sscg_options *opts)
-{
-  int security_level = get_security_level ();
-
-  opts->lifetime = 3650;
-  opts->dhparams_prime_len = 2048;
-  opts->dhparams_generator = 2;
-
-  /* Select the default key strength based on the system security level
-   * See:
-   * https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_get_security_level.html
-   * for the specification of the minimums.
-   */
-  switch (security_level)
-    {
-    case 0:
-    case 1:
-    case 2:
-      /* Security level 2 and below permits lower key-strengths, but SSCG
-       * will set a minimum of 2048 bits and the sha256 hash algorithm.
-       */
-      opts->hash_alg = talloc_strdup (opts, "sha256");
-      opts->key_strength = 2048;
-      break;
-
-    case 3:
-      opts->hash_alg = talloc_strdup (opts, "sha256");
-      opts->key_strength = 3072;
-      break;
-
-    case 4:
-      opts->hash_alg = talloc_strdup (opts, "sha384");
-      opts->key_strength = 7680;
-      break;
-
-    default:
-      /* Unknown security level. Default to the highest we know about */
-      fprintf (stderr,
-               "Unknown system security level %d. Defaulting to highest-known "
-               "level.\n",
-               security_level);
-      /* Fall through */
-
-    case 5:
-      opts->hash_alg = talloc_strdup (opts, "sha512");
-      opts->key_strength = 15360;
-      break;
-    }
-
-  opts->minimum_key_strength = opts->key_strength;
-
-  opts->cipher_alg = talloc_strdup (opts, "aes-256-cbc");
-
-  return 0;
-}
-
-static void
-print_options (struct sscg_options *opts)
-{
-  size_t i = 0;
-  fprintf (stdout, "==== Options ====\n");
-  fprintf (stdout, "Certificate lifetime: %d\n", opts->lifetime);
-  fprintf (stdout, "Country: \"%s\"\n", opts->country);
-  fprintf (stdout, "State or Principality: \"%s\"\n", opts->state);
-  fprintf (stdout, "Locality: \"%s\"\n", opts->locality);
-  fprintf (stdout, "Organization: \"%s\"\n", opts->org);
-  fprintf (stdout, "Organizational Unit: \"%s\"\n", opts->org_unit);
-  fprintf (stdout, "Email Address: \"%s\"\n", opts->email);
-  fprintf (stdout, "Hostname: \"%s\"\n", opts->hostname);
-  if (opts->subject_alt_names)
-    {
-      for (i = 0; opts->subject_alt_names[i]; i++)
-        {
-          fprintf (stdout,
-                   "Subject Alternative Name: \"%s\"\n",
-                   opts->subject_alt_names[i]);
-        }
-    }
-  fprintf (stdout, "=================\n");
-}
 
 
 const char *
@@ -184,48 +90,9 @@ sscg_get_file_type_name (enum sscg_file_type type)
 int
 main (int argc, const char **argv)
 {
-  int ret, sret, opt;
-  size_t i;
-  poptContext pc;
+  int ret, sret;
   struct sscg_options *options;
-  char *minimum_key_strength_help = NULL;
-
-  char *country = NULL;
-  char *state = NULL;
-  char *locality = NULL;
-  char *organization = NULL;
-  char *organizational_unit = NULL;
-  char *email = NULL;
-  char *hostname = NULL;
-  char *packagename;
-  char **alternative_names = NULL;
-
-  char *ca_file = NULL;
-  char *ca_key_file = NULL;
-  char *cert_file = NULL;
-  char *cert_key_file = NULL;
-  char *client_file = NULL;
-  char *client_key_file = NULL;
-  char *dhparams_file = NULL;
-
-  int ca_mode = SSCG_CERT_DEFAULT_MODE;
-  int ca_key_mode = SSCG_KEY_DEFAULT_MODE;
-  char *ca_key_password = NULL;
-  char *ca_key_passfile = NULL;
-
-  int crl_mode = SSCG_CERT_DEFAULT_MODE;
-  char *crl_file = NULL;
-
-  int cert_mode = SSCG_CERT_DEFAULT_MODE;
-  int cert_key_mode = SSCG_KEY_DEFAULT_MODE;
-  char *cert_key_password = NULL;
-  char *cert_key_passfile = NULL;
-
   bool build_client_cert = false;
-  int client_mode = SSCG_CERT_DEFAULT_MODE;
-  int client_key_mode = SSCG_KEY_DEFAULT_MODE;
-  char *client_key_password = NULL;
-  char *client_key_passfile = NULL;
 
   struct sscg_x509_cert *cacert;
   struct sscg_evp_pkey *cakey;
@@ -234,7 +101,6 @@ main (int argc, const char **argv)
   struct sscg_x509_cert *client_cert = NULL;
   struct sscg_evp_pkey *client_key = NULL;
 
-  int dhparams_mode = SSCG_CERT_DEFAULT_MODE;
   struct sscg_dhparams *dhparams = NULL;
 
   struct sscg_stream *stream = NULL;
@@ -254,727 +120,72 @@ main (int argc, const char **argv)
       return ENOMEM;
     }
 
-  options = talloc_zero (main_ctx, struct sscg_options);
-  CHECK_MEM (options);
-
-  options->streams =
-    talloc_zero_array (options, struct sscg_stream *, SSCG_NUM_FILE_TYPES);
-
-  ret = set_default_options (options);
-  if (ret != EOK)
-    goto done;
-
-  minimum_key_strength_help =
-    talloc_asprintf (main_ctx, "%d or larger", options->minimum_key_strength);
-
-  options->verbosity = SSCG_DEFAULT;
-  // clang-format off
-  struct poptOption long_options[] = {
-    POPT_AUTOHELP
-
-    {
-      "quiet",
-      'q',
-      POPT_ARG_VAL,
-      &options->verbosity,
-      SSCG_QUIET,
-       ("Display no output unless there is an error."),
-      NULL
-    },
-
-    {
-      "verbose",
-      'v',
-      POPT_ARG_VAL,
-      &options->verbosity,
-      SSCG_VERBOSE,
-      _ ("Display progress messages."),
-      NULL
-    },
-
-    {
-      "debug",
-      'd',
-      POPT_ARG_VAL,
-      &options->verbosity,
-      SSCG_DEBUG,
-      _ ("Enable logging of debug messages. Implies verbose. Warning! "
-         "This will print private key information to the screen!"),
-      NULL
-    },
-
-    {
-      "version",
-      'V',
-      POPT_ARG_NONE,
-      &options->print_version,
-      0,
-      _ ("Display the version number and exit."),
-      NULL
-    },
-
-    {
-      "force",
-      'f',
-      POPT_ARG_NONE,
-      &options->overwrite,
-      0,
-      _ ("Overwrite any pre-existing files in the requested locations"),
-      NULL
-    },
-
-    {
-      "lifetime",
-      '\0',
-      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
-      &options->lifetime,
-      0,
-      _ ("Certificate lifetime (days)."),
-      _ ("1-3650")
-    },
-
-    {
-      "country",
-      '\0',
-      POPT_ARG_STRING,
-      &country,
-      0,
-      _ ("Certificate DN: Country (C). (default: \"US\")"),
-      _ ("US, CZ, etc.")
-    },
-
-    {
-      "state",
-      '\0',
-      POPT_ARG_STRING,
-      &state,
-      0,
-      _ ("Certificate DN: State or Province (ST)."),
-      _ ("Massachusetts, British Columbia, etc.")
-    },
-
-    {
-      "locality",
-      '\0',
-      POPT_ARG_STRING,
-      &locality,
-      0,
-      _ ("Certificate DN: Locality (L)."),
-      _ ("Westford, Paris, etc.")
-    },
-
-    {
-      "organization",
-      '\0',
-      POPT_ARG_STRING,
-      &organization,
-      0,
-      _ ("Certificate DN: Organization (O). (default: \"Unspecified\")"),
-      _ ("My Company")
-    },
-
-    {
-      "organizational-unit",
-      '\0',
-      POPT_ARG_STRING,
-      &organizational_unit,
-      0,
-      _ ("Certificate DN: Organizational Unit (OU)."),
-      _ ("Engineering, etc.")
-    },
-
-    {
-      "email",
-      '\0',
-      POPT_ARG_STRING,
-      &email,
-      0,
-      _ ("Certificate DN: Email Address (Email)."),
-      _ ("myname@example.com")
-    },
-
-    {
-      "hostname",
-      '\0',
-      POPT_ARG_STRING,
-      &hostname,
-      0,
-      _ ("The valid hostname of the certificate. Must be an FQDN. (default: "
-         "current system FQDN)"),
-      _ ("server.example.com")
-    },
-
-    {
-      "subject-alt-name",
-      '\0',
-      POPT_ARG_ARGV,
-      &alternative_names,
-      0,
-      _ ("Optional additional valid hostnames for the certificate. "
-         "In addition to hostnames, this option also accepts explicit values "
-         "supported by RFC 5280 such as "
-         "IP:xxx.xxx.xxx.xxx/yyy.yyy.yyy.yyy "
-         "May be specified multiple times."),
-      _ ("alt.example.com")
-    },
-
-    {
-      "package",
-      '\0',
-      POPT_ARG_STRING,
-      &packagename,
-      0,
-      _ ("Unused. Retained for compatibility with earlier versions of sscg."),
-      NULL,
-    },
-
-    {
-      "key-strength",
-      '\0',
-      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
-      &options->key_strength,
-      0,
-      _ ("Strength of the certificate private keys in bits."),
-      minimum_key_strength_help },
-    {
-      "hash-alg",
-      '\0',
-      POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT,
-      &options->hash_alg,
-      0,
-      _ ("Hashing algorithm to use for signing."),
-      _ ("{sha256,sha384,sha512}"),
-    },
-
-    {
-      "cipher-alg",
-      '\0',
-      POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT,
-      &options->cipher_alg,
-      0,
-      _ ("Cipher to use for encrypting key files."),
-      _ ("{des-ede3-cbc,aes-256-cbc}"),
-    },
-
-    {
-      "ca-file",
-      '\0',
-      POPT_ARG_STRING,
-      &ca_file,
-      0,
-      _ ("Path where the public CA certificate will be stored. (default: "
-         "\"./ca.crt\")"),
-      NULL,
-    },
-
-    {
-      "ca-mode",
-      '\0',
-      POPT_ARG_INT,
-      &ca_mode,
-      0,
-      _ ("File mode of the created CA certificate."),
-      SSCG_CERT_DEFAULT_MODE_HELP,
-    },
-
-    {
-      "ca-key-file",
-      '\0',
-      POPT_ARG_STRING,
-      &ca_key_file,
-      0,
-      _ ("Path where the CA's private key will be stored. If unspecified, "
-         "the key will be destroyed rather than written to the disk."),
-      NULL,
-    },
-
-    {
-      "ca-key-mode",
-      '\0',
-      POPT_ARG_INT,
-      &ca_key_mode,
-      0,
-      _ ("File mode of the created CA key."),
-      SSCG_KEY_DEFAULT_MODE_HELP,
-    },
-
-    {
-      "ca-key-password",
-      '\0',
-      POPT_ARG_STRING,
-      &ca_key_password,
-      0,
-      _ ("Provide a password for the CA key file. Note that this will be "
-         "visible in the process table for all users, so it should be used "
-         "for testing purposes only. Use --ca-keypassfile or "
-         "--ca-key-password-prompt for secure password entry."),
-      NULL
-    },
-
-    {
-      "ca-key-passfile",
-      '\0',
-      POPT_ARG_STRING,
-      &ca_key_passfile,
-      0,
-      _ ("A file containing the password to encrypt the CA key file."),
-      NULL
-    },
-
-    {
-      "ca-key-password-prompt",
-      'C',
-      POPT_ARG_NONE,
-      &options->ca_key_pass_prompt,
-      0,
-      _ ("Prompt to enter a password for the CA key file."),
-      NULL
-    },
-
-    {
-      "crl-file",
-      '\0',
-      POPT_ARG_STRING,
-      &crl_file,
-      0,
-      _ ("Path where an (empty) Certificate Revocation List file will be "
-         "created, for applications that expect such a file to exist. If "
-         "unspecified, no such file will be created."),
-      NULL
-    },
-
-    {
-      "crl-mode",
-      '\0',
-      POPT_ARG_INT,
-      &crl_mode,
-      0,
-      _ ("File mode of the created Certificate Revocation List."),
-      SSCG_CERT_DEFAULT_MODE_HELP,
-    },
-
-    {
-      "cert-file",
-      '\0',
-      POPT_ARG_STRING,
-      &cert_file,
-      0,
-      _ ("Path where the public service certificate will be stored. "
-         "(default \"./service.pem\")"),
-      NULL,
-    },
-
-    {
-      "cert-mode",
-      '\0',
-      POPT_ARG_INT,
-      &cert_mode,
-      0,
-      _ ("File mode of the created certificate."),
-      SSCG_CERT_DEFAULT_MODE_HELP,
-    },
-
-    {
-      "cert-key-file",
-      '\0',
-      POPT_ARG_STRING,
-      &cert_key_file,
-      0,
-      _ ("Path where the service's private key will be stored. "
-         "(default \"service-key.pem\")"),
-      NULL,
-    },
-
-    {
-      "cert-key-mode",
-      '\0',
-      POPT_ARG_INT,
-      &cert_key_mode,
-      0,
-      _ ("File mode of the created certificate key."),
-      SSCG_KEY_DEFAULT_MODE_HELP,
-    },
-
-    {
-      "cert-key-password",
-      'p',
-      POPT_ARG_STRING,
-      &cert_key_password,
-      0,
-      _ ("Provide a password for the service key file. Note that this will be "
-         "visible in the process table for all users, so this flag should be "
-         "used for testing purposes only. Use --cert-keypassfile or "
-         "--cert-key-password-prompt for secure password entry."),
-      NULL
-    },
-
-    {
-      "cert-key-passfile",
-      '\0',
-      POPT_ARG_STRING,
-      &cert_key_passfile,
-      0,
-      _ ("A file containing the password to encrypt the service key file."),
-      NULL
-    },
-
-    {
-      "cert-key-password-prompt",
-      'P',
-      POPT_ARG_NONE,
-      &options->cert_key_pass_prompt,
-      0,
-      _ ("Prompt to enter a password for the service key file."),
-      NULL
-    },
-
-    {
-      "client-file",
-      '\0',
-      POPT_ARG_STRING,
-      &client_file,
-      0,
-      _ ("Path where a client authentication certificate will be stored."),
-      NULL
-    },
-    {
-      "client-mode",
-      '\0',
-      POPT_ARG_INT,
-      &client_mode,
-      0,
-      _ ("File mode of the created certificate."),
-      SSCG_CERT_DEFAULT_MODE_HELP,
-    },
-
-    {
-      "client-key-file",
-      '\0',
-      POPT_ARG_STRING,
-      &client_key_file,
-      0,
-      _ ("Path where the client's private key will be stored. "
-         "(default is the client-file)"),
-      NULL,
-    },
-
-    {
-      "client-key-mode",
-      '\0',
-      POPT_ARG_INT,
-      &client_key_mode,
-      0,
-      _ ("File mode of the created certificate key."),
-      SSCG_KEY_DEFAULT_MODE_HELP,
-    },
-
-    {
-      "client-key-password",
-      '\0',
-      POPT_ARG_STRING,
-      &client_key_password,
-      0,
-      _ ("Provide a password for the client key file. Note that this will be "
-         "visible in the process table for all users, so this flag should be "
-         "used for testing purposes only. Use --client-keypassfile or "
-         "--client-key-password-prompt for secure password entry."),
-      NULL
-    },
-
-    {
-      "client-key-passfile",
-      '\0',
-      POPT_ARG_STRING,
-      &client_key_passfile,
-      0,
-      _ ("A file containing the password to encrypt the client key file."),
-      NULL
-    },
-
-    {
-      "client-key-password-prompt",
-      '\0',
-      POPT_ARG_NONE,
-      &options->client_key_pass_prompt,
-      0,
-      _ ("Prompt to enter a password for the client key file."),
-      NULL
-    },
-
-    {
-      "dhparams-file",
-      '\0',
-      POPT_ARG_STRING,
-      &dhparams_file,
-      0,
-      _("A file to contain a set of generated Diffie-Hellman parameters. "
-        "If unspecified, no such file will be created."),
-      NULL
-    },
-
-    {
-      "dhparams-prime-len",
-      '\0',
-      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
-      &options->dhparams_prime_len,
-      0,
-      _ ("The length of the prime number to generate for dhparams, in bits."),
-      NULL
-    },
-
-    {
-      "dhparams-generator",
-      '\0',
-      POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,
-      &options->dhparams_generator,
-      0,
-      _ ("The generator value for dhparams."),
-      _("{2,3,5}")
-    },
-
-    POPT_TABLEEND
-  };
-  // clang-format on
-
-  pc = poptGetContext (argv[0], argc, argv, long_options, 0);
-  while ((opt = poptGetNextOpt (pc)) != -1)
-    {
-      switch (opt)
-        {
-        default:
-          fprintf (stderr,
-                   "\nInvalid option %s: %s\n\n",
-                   poptBadOption (pc, 0),
-                   poptStrerror (opt));
-          poptPrintUsage (pc, stderr, 0);
-          return 1;
-        }
-    }
-
-  if (options->print_version)
-    {
-      /* Print the version number and exit */
-      printf ("%s\n", PACKAGE_VERSION);
-      return 0;
-    }
-
-  verbosity = options->verbosity;
-
-  /* Process the Subject information */
-
-  if (country)
-    {
-      if (strlen (country) != 2)
-        {
-          fprintf (stderr, "Country codes must be exactly two letters.\n");
-          ret = EINVAL;
-          goto done;
-        }
-      options->country = talloc_strdup (options, country);
-    }
-  else
-    {
-      /* Country name is mandatory. 1.0 (in Golang) defaulted to
-           "US", so we'll keep it the same to avoid breaking existing
-           usages. */
-      options->country = talloc_strdup (options, "US");
-    }
-  CHECK_MEM (options->country);
-
-  if (state)
-    {
-      options->state = talloc_strdup (options, state);
-    }
-  else
-    {
-      options->state = talloc_strdup (options, "");
-    }
-  CHECK_MEM (options->state);
-
-  if (locality)
-    {
-      options->locality = talloc_strdup (options, locality);
-    }
-  else
-    {
-      options->locality = talloc_strdup (options, "");
-    }
-  CHECK_MEM (options->locality);
-
-  if (organization)
-    {
-      options->org = talloc_strdup (options, organization);
-    }
-  else
-    {
-      /* In 1.0 (Golang), organization defaulted to "Unspecified".
-           Keep it the same here to avoid breaking existing usages. */
-      options->org = talloc_strdup (options, "Unspecified");
-    }
-  CHECK_MEM (options->org);
-
-  if (organizational_unit)
-    {
-      options->org_unit = talloc_strdup (options, organizational_unit);
-    }
-  else
-    {
-      options->org_unit = talloc_strdup (options, "");
-    }
-  CHECK_MEM (options->org_unit);
-
-  if (email)
-    {
-      options->email = talloc_strdup (options, email);
-    }
-  else
-    {
-      options->email = talloc_strdup (options, "");
-    }
-  CHECK_MEM (options->email);
-
-  if (hostname)
-    {
-      options->hostname = talloc_strdup (options, hostname);
-    }
-  else
-    {
-      /* Get hostname from the system */
-      hostname = talloc_zero_array (options, char, HOST_NAME_MAX + 1);
-      CHECK_MEM (hostname);
-
-      sret = gethostname (hostname, HOST_NAME_MAX);
-      if (sret != 0)
-        {
-          ret = errno;
-          goto done;
-        }
-
-      options->hostname = hostname;
-    }
-  CHECK_MEM (options->hostname);
-
-  if (strnlen (options->hostname, MAXHOSTNAMELEN + 1) > MAXHOSTNAMELEN)
-    {
-      fprintf (
-        stderr, "Hostnames may not exceed %d characters\n", MAXHOSTNAMELEN);
-      ret = EINVAL;
-      goto done;
-    }
-
-  /* Use a realloc loop to copy the names from popt into the
-       options struct. It's not the most efficient approach, but
-       it's only done one time, so there is no sense in optimizing
-       it. */
-  if (alternative_names)
-    {
-      i = 0;
-      while (alternative_names[i] != NULL)
-        {
-          options->subject_alt_names = talloc_realloc (
-            options, options->subject_alt_names, char *, i + 2);
-          CHECK_MEM (options->subject_alt_names);
-
-          options->subject_alt_names[i] =
-            talloc_strdup (options->subject_alt_names, alternative_names[i]);
-          CHECK_MEM (options->subject_alt_names[i]);
-
-          /* Add a NULL terminator to the end */
-          options->subject_alt_names[i + 1] = NULL;
-          i++;
-        }
-    }
-
-  if (options->key_strength < options->minimum_key_strength)
-    {
-      fprintf (stderr,
-               "Key strength must be at least %d bits.\n",
-               options->minimum_key_strength);
-      ret = EINVAL;
-      goto done;
-    }
-
-  /* Make sure we have a valid cipher */
-  options->cipher = EVP_get_cipherbyname (options->cipher_alg);
-  if (!options->cipher)
-    {
-      fprintf (stderr, "Invalid cipher specified: %s\n", options->cipher_alg);
-      ret = EINVAL;
-      goto done;
-    }
-
-  /* TODO: restrict this to approved hashes.
-   * For now, we'll only list SHA[256|384|512] in the help */
-  options->hash_fn = EVP_get_digestbyname (options->hash_alg);
-
-  if (!options->hash_fn)
-    {
-      fprintf (stderr, "Unsupported hashing algorithm.");
-      ret = EINVAL;
-      goto done;
-    }
-
-  /* On verbose logging, display all of the selected options. */
-  if (options->verbosity >= SSCG_VERBOSE)
-    print_options (options);
+  ret = sscg_handle_arguments (main_ctx, argc, argv, &options);
+  CHECK_OK (ret);
 
   /* Prepare the output files */
   ret = sscg_io_utils_add_output_file (options->streams,
                                        SSCG_FILE_TYPE_CA,
-                                       ca_file ? ca_file : "./ca.crt",
-                                       ca_mode);
+                                       options->ca_file ? options->ca_file :
+                                                          "./ca.crt",
+                                       options->ca_mode);
   CHECK_OK (ret);
 
   ret = sscg_io_utils_add_output_key (options->streams,
                                       SSCG_FILE_TYPE_CA_KEY,
-                                      ca_key_file,
-                                      ca_key_mode,
+                                      options->ca_key_file,
+                                      options->ca_key_mode,
                                       options->ca_key_pass_prompt,
-                                      ca_key_password,
-                                      ca_key_passfile);
+                                      options->ca_key_password,
+                                      options->ca_key_passfile);
+  CHECK_OK (ret);
+
+  ret = sscg_io_utils_add_output_file (
+    options->streams,
+    SSCG_FILE_TYPE_SVC,
+    options->cert_file ? options->cert_file : "./service.pem",
+    options->cert_mode);
+  CHECK_OK (ret);
+
+  ret = sscg_io_utils_add_output_key (
+    options->streams,
+    SSCG_FILE_TYPE_SVC_KEY,
+    options->cert_key_file ? options->cert_key_file : "./service-key.pem",
+    options->cert_key_mode,
+    options->cert_key_pass_prompt,
+    options->cert_key_password,
+    options->cert_key_passfile);
+  CHECK_OK (ret);
+
+
+  ret = sscg_io_utils_add_output_file (options->streams,
+                                       SSCG_FILE_TYPE_CLIENT,
+                                       options->client_file,
+                                       options->client_mode);
+  CHECK_OK (ret);
+
+
+  ret = sscg_io_utils_add_output_key (
+    options->streams,
+    SSCG_FILE_TYPE_CLIENT_KEY,
+    options->client_key_file ? options->client_key_file : options->client_file,
+    options->client_key_mode,
+    options->client_key_pass_prompt,
+    options->client_key_password,
+    options->client_key_passfile);
   CHECK_OK (ret);
 
   ret = sscg_io_utils_add_output_file (options->streams,
-                                       SSCG_FILE_TYPE_SVC,
-                                       cert_file ? cert_file : "./service.pem",
-                                       cert_mode);
+                                       SSCG_FILE_TYPE_CRL,
+                                       options->crl_file,
+                                       options->crl_mode);
   CHECK_OK (ret);
 
-  ret = sscg_io_utils_add_output_key (options->streams,
-                                      SSCG_FILE_TYPE_SVC_KEY,
-                                      cert_key_file ? cert_key_file :
-                                                      "./service-key.pem",
-                                      cert_key_mode,
-                                      options->cert_key_pass_prompt,
-                                      cert_key_password,
-                                      cert_key_passfile);
+  ret = sscg_io_utils_add_output_file (options->streams,
+                                       SSCG_FILE_TYPE_DHPARAMS,
+                                       options->dhparams_file,
+                                       options->dhparams_mode);
   CHECK_OK (ret);
-
-
-  ret = sscg_io_utils_add_output_file (
-    options->streams, SSCG_FILE_TYPE_CLIENT, client_file, client_mode);
-  CHECK_OK (ret);
-
-
-  ret = sscg_io_utils_add_output_key (options->streams,
-                                      SSCG_FILE_TYPE_CLIENT_KEY,
-                                      client_key_file ? client_key_file :
-                                                        client_file,
-                                      client_key_mode,
-                                      options->client_key_pass_prompt,
-                                      client_key_password,
-                                      client_key_passfile);
-  CHECK_OK (ret);
-
-  ret = sscg_io_utils_add_output_file (
-    options->streams, SSCG_FILE_TYPE_CRL, crl_file, crl_mode);
-  CHECK_OK (ret);
-
-  ret = sscg_io_utils_add_output_file (
-    options->streams, SSCG_FILE_TYPE_DHPARAMS, dhparams_file, dhparams_mode);
-  CHECK_OK (ret);
-
-  poptFreeContext (pc);
 
   /* Validate and open the file paths */
   ret = sscg_io_utils_open_output_files (options->streams, options->overwrite);

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -101,7 +101,8 @@ main (int argc, const char **argv)
   struct sscg_x509_cert *client_cert = NULL;
   struct sscg_evp_pkey *client_key = NULL;
 
-  struct sscg_dhparams *dhparams = NULL;
+  BIO *bp;
+  EVP_PKEY *dhparams = NULL;
 
   struct sscg_stream *stream = NULL;
 
@@ -280,24 +281,24 @@ main (int argc, const char **argv)
 
 
   /* Create DH parameters file */
-  if (GET_BIO (SSCG_FILE_TYPE_DHPARAMS))
+  bp = GET_BIO (SSCG_FILE_TYPE_DHPARAMS);
+  if (bp)
     {
       /* Open the file before generating the parameters. This avoids wasting
        * the time to generate them if the destination is not writable.
        */
 
-      ret = create_dhparams (main_ctx,
-                             options->verbosity,
+      ret = create_dhparams (options->verbosity,
                              options->dhparams_prime_len,
                              options->dhparams_generator,
                              &dhparams);
       CHECK_OK (ret);
 
       /* Export the DH parameters to the file */
-      sret = PEM_write_bio_DHparams (GET_BIO (SSCG_FILE_TYPE_DHPARAMS),
-                                     dhparams->dh);
-      CHECK_SSL (sret, PEM_write_bio_DHparams ());
+      sret = PEM_write_bio_Parameters (bp, dhparams);
+      CHECK_SSL (sret, PEM_write_bio_Parameters ());
       ANNOUNCE_WRITE (SSCG_FILE_TYPE_DHPARAMS);
+      EVP_PKEY_free (dhparams);
     }
 
 

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -44,15 +44,11 @@ int verbosity;
 static int
 get_security_level (void)
 {
-#ifdef HAVE_SSL_CTX_GET_SECURITY_LEVEL
   SSL_CTX *ssl_ctx = SSL_CTX_new (TLS_method ());
   int security_level = SSL_CTX_get_security_level (ssl_ctx);
   SSL_CTX_free (ssl_ctx);
   ssl_ctx = NULL;
   return security_level;
-#else
-  return 0;
-#endif
 }
 
 static int
@@ -247,11 +243,6 @@ main (int argc, const char **argv)
        This means that it's opened as write-only by the effective
        user. */
   umask (0577);
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-  /* In OpenSSL <1.1.0, we need to initialize the library. */
-  OpenSSL_add_all_algorithms ();
-#endif
 
   if (getenv ("SSCG_TALLOC_REPORT"))
     talloc_enable_null_tracking ();

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -282,24 +282,25 @@ main (int argc, const char **argv)
 
   /* Create DH parameters file */
   bp = GET_BIO (SSCG_FILE_TYPE_DHPARAMS);
-  if (bp)
+  if (options->dhparams_prime_len > 0)
     {
-      /* Open the file before generating the parameters. This avoids wasting
-       * the time to generate them if the destination is not writable.
-       */
-
       ret = create_dhparams (options->verbosity,
                              options->dhparams_prime_len,
                              options->dhparams_generator,
                              &dhparams);
       CHECK_OK (ret);
-
-      /* Export the DH parameters to the file */
-      sret = PEM_write_bio_Parameters (bp, dhparams);
-      CHECK_SSL (sret, PEM_write_bio_Parameters ());
-      ANNOUNCE_WRITE (SSCG_FILE_TYPE_DHPARAMS);
-      EVP_PKEY_free (dhparams);
     }
+  else
+    {
+      ret = get_params_by_named_group (options->dhparams_group, &dhparams);
+      CHECK_OK (ret);
+    }
+
+  /* Export the DH parameters to the file */
+  sret = PEM_write_bio_Parameters (bp, dhparams);
+  CHECK_SSL (sret, PEM_write_bio_Parameters ());
+  ANNOUNCE_WRITE (SSCG_FILE_TYPE_DHPARAMS);
+  EVP_PKEY_free (dhparams);
 
 
   /* Set the final file permissions */

--- a/src/x509.c
+++ b/src/x509.c
@@ -48,11 +48,11 @@ sscg_generate_serial (TALLOC_CTX *mem_ctx, struct sscg_bignum **serial)
        could be printed by BN_get_word() later. We omit the last bit
        in order to ensure that we can't randomly get 0xffffffffL, which
        is reserved by BN_get_word() to mean "too large to represent". */
-  bnret = BN_pseudo_rand (bn->bn,
-                          (sizeof (unsigned long) * CHAR_BIT) - 1,
-                          BN_RAND_TOP_ANY,
-                          BN_RAND_BOTTOM_ANY);
-  CHECK_SSL (bnret, BN_pseudo_rand);
+  bnret = BN_rand (bn->bn,
+                   (sizeof (unsigned long) * CHAR_BIT) - 1,
+                   BN_RAND_TOP_ANY,
+                   BN_RAND_BOTTOM_ANY);
+  CHECK_SSL (bnret, BN_rand);
 
   ret = EOK;
 

--- a/test/create_ca_test.c
+++ b/test/create_ca_test.c
@@ -30,7 +30,7 @@ main (int argc, char **argv)
 {
   int ret, bits;
   struct sscg_cert_info *certinfo;
-  struct sscg_bignum *e, *serial;
+  struct sscg_bignum *serial;
   struct sscg_x509_req *csr = NULL;
   struct sscg_evp_pkey *pkey = NULL;
   struct sscg_x509_cert *cert = NULL;
@@ -80,10 +80,7 @@ main (int argc, char **argv)
   /* Generate an RSA keypair */
   bits = 4096;
 
-  ret = sscg_init_bignum (tmp_ctx, RSA_F4, &e);
-  CHECK_OK (ret);
-
-  ret = sscg_generate_rsa_key (certinfo, bits, e, &pkey);
+  ret = sscg_generate_rsa_key (certinfo, bits, &pkey);
   CHECK_OK (ret);
 
   /* Create the CSR */

--- a/test/create_csr_test.c
+++ b/test/create_csr_test.c
@@ -30,7 +30,6 @@ main (int argc, char **argv)
 {
   int ret, bits;
   struct sscg_cert_info *certinfo;
-  struct sscg_bignum *e;
   struct sscg_x509_req *csr = NULL;
   struct sscg_evp_pkey *pkey = NULL;
 
@@ -79,10 +78,7 @@ main (int argc, char **argv)
   /* Generate an RSA keypair */
   bits = 4096;
 
-  ret = sscg_init_bignum (tmp_ctx, RSA_F4, &e);
-  CHECK_OK (ret);
-
-  ret = sscg_generate_rsa_key (certinfo, bits, e, &pkey);
+  ret = sscg_generate_rsa_key (certinfo, bits, &pkey);
   CHECK_OK (ret);
 
   /* Create the CSR */

--- a/test/named_dhparams_test.c
+++ b/test/named_dhparams_test.c
@@ -1,0 +1,146 @@
+/*
+    This file is part of sscg.
+
+    sscg is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    sscg is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with sscg.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2019 by Stephen Gallagher <sgallagh@redhat.com>
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <talloc.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+#include "include/sscg.h"
+#include "include/dhparams.h"
+
+
+static int
+test_valid_named_groups (void)
+{
+  int ret;
+  size_t i = 0;
+  EVP_PKEY *dhparams = NULL;
+  EVP_PKEY_CTX *pctx = NULL;
+
+  if (getenv ("SSCG_SKIP_DHPARAMS"))
+    {
+      /* Skip this test */
+      return 77;
+    }
+
+  while (dh_fips_groups[i])
+    {
+      printf("Testing %s\n", dh_fips_groups[i]);
+      ret = get_params_by_named_group (dh_fips_groups[i], &dhparams);
+      if (ret != EOK) {
+        fprintf (stderr,
+                 "Could not retrieve named DH parameters.");
+        goto done;
+      }
+
+      pctx = EVP_PKEY_CTX_new(dhparams, NULL);
+      if (!EVP_PKEY_param_check(pctx))
+        {
+          ERR_print_errors_fp (stderr);
+          ret = EIO;
+          goto done;
+        }
+
+      i++;
+
+      EVP_PKEY_CTX_free (pctx);
+      pctx = NULL;
+
+      EVP_PKEY_free (dhparams);
+      dhparams = NULL;
+    }
+
+  ret = EOK;
+
+done:
+  EVP_PKEY_free (dhparams);
+  EVP_PKEY_CTX_free (pctx);
+  return ret;
+}
+
+
+static int
+test_invalid_named_groups (void)
+{
+  int ret;
+  EVP_PKEY *dhparams = NULL;
+  TALLOC_CTX *tmp_ctx = NULL;
+  char *name = NULL;
+
+  if (getenv ("SSCG_SKIP_DHPARAMS"))
+    {
+      /* Skip this test */
+      return 77;
+    }
+
+  tmp_ctx = talloc_new (NULL);
+
+  printf("Testing empty string\n");
+  ret = get_params_by_named_group ("", &dhparams);
+  if (ret != EINVAL) {
+    fprintf (stderr,
+             "Received [%s] return code.", strerror(ret));
+    ret = EINVAL;
+    goto done;
+  }
+
+
+  printf("Testing long, unterminated string\n");
+  name = talloc_array (tmp_ctx, char, 10 * 1024 * 1024 + 1);
+  memset (name, 'a', 10 * 1024 * 1024);
+  ret = get_params_by_named_group (name, &dhparams);
+  if (ret != EINVAL) {
+    fprintf (stderr,
+             "Received [%s] return code.", strerror(ret));
+    ret = EINVAL;
+    goto done;
+  }
+  talloc_zfree (name);
+
+
+  EVP_PKEY_free (dhparams);
+  dhparams = NULL;
+
+  ret = EOK;
+
+done:
+  EVP_PKEY_free (dhparams);
+  return ret;
+}
+
+
+int
+main (int argc, char **argv)
+{
+  int ret = EOK;
+
+  ret = test_valid_named_groups ();
+  if (ret != EOK) goto done;
+
+  ret = test_invalid_named_groups ();
+  if (ret != EOK) goto done;
+
+  ret = EOK;
+
+done:
+  return ret;
+}

--- a/test/named_dhparams_test.c
+++ b/test/named_dhparams_test.c
@@ -29,6 +29,41 @@
 
 
 static int
+test_group_name_list (void)
+{
+  int ret;
+  TALLOC_CTX *tmp_ctx = talloc_new (NULL);
+  char *names = valid_dh_group_names (tmp_ctx);
+  if (!names)
+    {
+      ret = EINVAL;
+      goto done;
+    }
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+  if (strcmp(names, "ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192") != 0)
+    {
+      ret = EINVAL;
+      goto done;
+    }
+#else
+    if (strcmp(names, "ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, modp_2048, modp_3072, modp_4096, modp_6144, modp_8192, modp_1536, dh_1024_160, dh_2048_224, dh_2048_256") != 0)
+    {
+      ret = EINVAL;
+      goto done;
+    }
+#endif
+
+
+  ret = EOK;
+
+done:
+  talloc_free (tmp_ctx);
+  return ret;
+}
+
+
+static int
 test_valid_named_groups (void)
 {
   int ret;
@@ -137,6 +172,9 @@ main (int argc, char **argv)
   if (ret != EOK) goto done;
 
   ret = test_invalid_named_groups ();
+  if (ret != EOK) goto done;
+
+  ret = test_group_name_list ();
   if (ret != EOK) goto done;
 
   ret = EOK;


### PR DESCRIPTION
# Changes for sscg 3.0

## New features
* Support for OpenSSL 3.0
* Support for outputting named Diffie-Hellman parameter groups
* Support for CentOS Stream 9

## Major version notes
* SSCG now requires OpenSSL 1.1.0 or later.
* sscg will now always output DH parameters to a PEM file. It will default to using the `ffdhe4096` group.
* Generated certificate lifetime now defaults to 398 days, rather than ten years to conform to [modern browser expectations](https://chromium-review.googlesource.com/c/chromium/src/+/2258372).