### PR TITLE
Debian packaging updates, fix build failures due to test timeout, fix CI on Fedora/CentOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,7 @@ jobs:
 
     container:
       image: fedora:${{ matrix.release }}
+      options: --security-opt seccomp=unconfined
 
     steps:
     - name: Identify the system
@@ -238,6 +239,7 @@ jobs:
 
     container:
       image: quay.io/centos/centos:stream9-development
+      options: --security-opt seccomp=unconfined
 
     steps:
     - name: Identify the system

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         os:
 #         https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1936975
@@ -79,6 +80,7 @@ jobs:
     name: Fedora x86_64
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         release:
           - 33
@@ -120,6 +122,7 @@ jobs:
     name: Fedora non-x86_64
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - aarch64
@@ -157,6 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         release:
           - 7
@@ -224,6 +228,7 @@ jobs:
     continue-on-error: false
 
     strategy:
+      fail-fast: false
       matrix:
         release:
           - 9

--- a/meson.build
+++ b/meson.build
@@ -218,7 +218,8 @@ named_dhparams_test = executable(
     dependencies: [ crypto ],
     install : false,
 )
-test('named_dhparams_test', named_dhparams_test, timeout : 60)
+# takes *very* long on some architectures like Debian armel
+test('named_dhparams_test', named_dhparams_test, timeout : 2700)
 
 
 cdata = configuration_data()

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -12,7 +12,7 @@ Build-Depends: debhelper-compat (= 12),
 Maintainer: Stephen Gallagher <sgallagh@redhat.com>
 Uploaders: Martin Pitt <mpitt@debian.org>
 Homepage: https://github.com/sgallagher/sscg/
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Rules-Requires-Root: no
 
 Package: sscg

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -12,6 +12,8 @@ Build-Depends: debhelper-compat (= 12),
 Maintainer: Stephen Gallagher <sgallagh@redhat.com>
 Uploaders: Martin Pitt <mpitt@debian.org>
 Homepage: https://github.com/sgallagher/sscg/
+Vcs-Git: https://salsa.debian.org/debian/sscg.git
+Vcs-Browser: https://salsa.debian.org/debian/sscg
 Standards-Version: 4.6.0
 Rules-Requires-Root: no
 


### PR DESCRIPTION
sscg recently got accepted into Debian, and the first build failed on most architectures, like [this one](https://buildd.debian.org/status/fetch.php?pkg=sscg&arch=arm64&ver=3.0.0-2&stamp=1629713190&raw=0).

Increasing the timeout helps, the package now [builds fine](https://buildd.debian.org/status/package.php?p=sscg) on most architectures. The failures on the other architectures are unrelated (and not that important right now, none of them are officially supported). I may send a fix for building on FreeBSD soon, though.

The packaging updates are already applied in https://salsa.debian.org/debian/sscg, this syncs them back to upstream.