### PR TITLE
Correct certificate lifetime calculation

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -418,7 +418,7 @@ sscg_sign_x509_csr (TALLOC_CTX *mem_ctx,
 
   /* set time */
   X509_gmtime_adj (X509_get_notBefore (cert), 0);
-  X509_gmtime_adj (X509_get_notAfter (cert), days * 24 * 3650);
+  X509_gmtime_adj (X509_get_notAfter (cert), days * 24 * 60 * 60);
 
   /* set subject */
   subject = X509_NAME_dup (X509_REQ_get_subject_name (csr));


### PR DESCRIPTION
sscg allows passing the certificate lifetime, as a number of days, as a
commandline argument.  It converts this value to seconds using the
formula

  days * 24 * 3650

which is incorrect.  The correct value is 3600.

This effectively adds an extra 20 minutes to the lifetime of the
certificate for each day as given on the commandline, and was enough to
cause some new integration tests in cockpit to fail.

Interestingly, 3650 is the old default value for the number of days of
certificate validity (~10 years) so this probably slipped in as a sort
of muscle-memory-assisted typo.

Let's just write `24 * 60 * 60` to make things clear.