### PR TITLE
simplify packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,36 +1,20 @@
 ---
 specfile_path: packaging/fedora/sscg.spec
 
-patch_generation_ignore_paths:
-  - "packaging/"
-  - ".ci/"
-  - ".github/"
-  - ".subprojects/"
+# this is not being utilized for regular upstream integration since patches are not being taken care of in such a case
+# if you wanted to take care of patches, you'd need to set `upstream_ref: sscg-3.0.0` to get patches generated from commits on top of sscg-3.0.0
+# patch_generation_ignore_paths:
+#   - "packaging/"
+#   - ".ci/"
+#   - ".github/"
+#   - ".subprojects/"
 
 upstream_tag_template: "sscg-{version}"
-
-notifications:
-  pull_request:
-    successful_build: false
-
-synced_files:
-  - .packit.yaml
-  - src: packaging/fedora/*
-    dest: .
 
 sync_changelog: true
 
 
 jobs:
-- job: copr_build
-  trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
-    - centos-stream-8
-    - epel-8
-
-
 - job: tests
   trigger: pull_request
   metadata:


### PR DESCRIPTION
* all the items dropped are defaults
* this will also yield less check lines: build and test will be combined