### PR TITLE
Debian packaging: Accept *.tar.gz files as well, bump test timeouts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -133,7 +133,7 @@ create_ca_test = executable(
         dependencies: [ crypto ],
     install:false,
 )
-test('create_ca_test', create_ca_test)
+test('create_ca_test', create_ca_test, timeout: 120)
 
 create_csr_test = executable(
     'create_csr_test',
@@ -151,7 +151,7 @@ generate_rsa_key_test = executable(
         dependencies: [ crypto ],
     install:false,
 )
-test('generate_rsa_key_test', generate_rsa_key_test)
+test('generate_rsa_key_test', generate_rsa_key_test, timeout: 120)
 
 generate_serial_test = executable(
     'generate_serial_test',
@@ -177,7 +177,7 @@ test('init_bignum_test', init_bignum_test)
 # excluded from the test suite by default.
 
 prime_lengths = [ 512, 1024 ]
-dhparam_timeout = 120
+dhparam_timeout = 240
 
 if get_option('run_slow_tests')
     prime_lengths = prime_lengths + [ 2048, 4096 ]

--- a/packaging/debian/watch
+++ b/packaging/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://github.com/sgallagher/sscg/releases/ .*/sscg-([\d\.]+)\.tar\.xz
+https://github.com/sgallagher/sscg/releases/ .*/sscg-([\d\.]+)\.tar\.[gx]z


### PR DESCRIPTION
Upstream version 3.0.1 dropped custom release artifacts and just relies
on the automatic `git archive` tarballs.

---

This unbreaks automated "new upstream release" notification/watching on https://tracker.debian.org/pkg/sscg