### PR TITLE
dhparams: Fix the FIPS_mode() call for OpenSSL 3.0

### DIFF
--- a/src/dhparams.c
+++ b/src/dhparams.c
@@ -234,7 +234,11 @@ is_valid_named_group (const char *group_name)
     }
 
   /* Check non-FIPS groups */
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   if (!FIPS_mode ())
+#else
+  if (!EVP_default_properties_is_fips_enabled(NULL))
+#endif
     {
       i = 0;
       while (dh_nonfips_groups[i])


### PR DESCRIPTION
This function has been removed from OpenSSL 3.0, replaced by
EVP_default_properties_is_fips_enabled().

Closes #50