### PR TITLE
Debian packaging: Drop obsolete popt paragraph

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -26,29 +26,3 @@ License: GPL-3+ with OpenSSL exception
  .
  The full text of the GPL is distributed as in
  /usr/share/common-licenses/GPL-3 on Debian systems.
-
-Files: subprojects/popt/*
-Copyright: (C) 1998-2002 Red Hat, Inc.
- (c) 2010-2011 Elia Pinto <devzero2000@rpm5.org>
- (c) 1998 by Addison Wesley Longman, Inc.
-License: X11
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
- X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
- AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- .
- Except as contained in this notice, the name of the X Consortium shall not be
- used in advertising or otherwise to promote the sale, use or other dealings
- in this Software without prior written authorization from the X Consortium.


### PR DESCRIPTION
popt got removed in commit 69bc3844de9b2b