### PR TITLE
Packit: Drop redundant epel-8 build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,7 +30,6 @@ jobs:
     targets:
     - fedora-all
     - centos-stream-8
-    - epel-8
 - job: propose_downstream
   trigger: release
   metadata:


### PR DESCRIPTION
It was duplicating the work of the centos-stream-8 build