### PR TITLE
Truncate IP address in SAN

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -133,6 +133,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   char *alt_name = NULL;
   char *tmp = NULL;
   char *san = NULL;
+  char *slash = NULL;
   TALLOC_CTX *tmp_ctx;
   X509_EXTENSION *ex = NULL;
   struct sscg_x509_req *csr;
@@ -267,6 +268,12 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
           else
             {
               san = talloc_strdup (tmp_ctx, certinfo->subject_alt_names[i]);
+              /* SAN IP addresses cannot include the subnet mask */
+              if ((slash = strchr (san, '/')))
+                {
+                  /* Truncate at the slash */
+                  *slash = '\0';
+                }
             }
           CHECK_MEM (san);
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -289,7 +289,13 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
     }
 
   ex = X509V3_EXT_conf_nid (NULL, NULL, NID_subject_alt_name, alt_name);
-  CHECK_MEM (ex);
+  if (!ex)
+    {
+      ret = EINVAL;
+      fprintf (stderr, "Invalid subjectAlternativeName: %s\n", alt_name);
+      goto done;
+    }
+
   sk_X509_EXTENSION_push (certinfo->extensions, ex);
 
   /* Set the public key for the certificate */


### PR DESCRIPTION
In OpenSSL 1.1, this was done automatically when addind a SAN extension,
but in OpenSSL 3.0 it is rejected as an invalid input.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

Attn: @mvollmer