### PR TITLE
Increase create_csr_test unit test timeout

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -142,7 +142,7 @@ create_csr_test = executable(
         dependencies: [ crypto ],
     install:false,
 )
-test('create_csr_test', create_csr_test)
+test('create_csr_test', create_csr_test, timeout: 120)
 
 generate_rsa_key_test = executable(
     'generate_rsa_key_test',

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -14,7 +14,7 @@ Uploaders: Martin Pitt <mpitt@debian.org>
 Homepage: https://github.com/sgallagher/sscg/
 Vcs-Git: https://salsa.debian.org/debian/sscg.git
 Vcs-Browser: https://salsa.debian.org/debian/sscg
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 
 Package: sscg


### PR DESCRIPTION
30 seconds is often not enough on slow/emulated architectures like
riscv64.

https://bugs.debian.org/1014259
