### PR TITLE
Extend maximum DNS name to 255

### DIFF
--- a/include/sscg.h
+++ b/include/sscg.h
@@ -313,6 +313,9 @@ enum sscg_cert_type
 #define SSCG_MIN_KEY_PASS_LEN 4
 #define SSCG_MAX_KEY_PASS_LEN 1023
 
+/* RFC 1035, section 2.3.4 (Size Limits) */
+#define MAX_HOST_LEN 63
+#define MAX_FQDN_LEN 255
 
 int
 sscg_handle_arguments (TALLOC_CTX *mem_ctx,

--- a/src/cert.c
+++ b/src/cert.c
@@ -31,6 +31,7 @@
 */
 
 
+#include <string.h>
 #include "include/sscg.h"
 #include "include/cert.h"
 #include "include/x509.h"
@@ -52,6 +53,7 @@ create_cert (TALLOC_CTX *mem_ctx,
   struct sscg_x509_req *csr;
   struct sscg_evp_pkey *pkey;
   struct sscg_x509_cert *cert;
+  char *dot;
   X509_EXTENSION *ex = NULL;
   EXTENDED_KEY_USAGE *extended;
   TALLOC_CTX *tmp_ctx = NULL;
@@ -87,6 +89,9 @@ create_cert (TALLOC_CTX *mem_ctx,
 
   certinfo->cn = talloc_strdup (certinfo, options->hostname);
   CHECK_MEM (certinfo->cn);
+  /* Truncate the CN at the first dot */
+  if ((dot = strchr (certinfo->cn, '.')))
+    *dot = '\0';
 
   if (options->subject_alt_names)
     {

--- a/src/x509.c
+++ b/src/x509.c
@@ -290,12 +290,12 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
             }
           CHECK_MEM (san);
 
-          if (strnlen (san, MAXHOSTNAMELEN + 5) > MAXHOSTNAMELEN + 4)
+          if (strnlen (san, MAX_FQDN_LEN + 5) > MAX_FQDN_LEN + 4)
             {
               fprintf (stderr,
-                       "Hostnames may not exceed %d characters in Subject "
+                       "FQDNs may not exceed %d characters in Subject "
                        "Alternative Names\n",
-                       MAXHOSTNAMELEN);
+                       MAX_FQDN_LEN);
               ret = EINVAL;
               goto done;
             }


### PR DESCRIPTION
The hostname part is still restricted to 63 characters

See RFC 1035, section 2.3.4