### PR TITLE
x509: Use proper version for CSR.

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -169,7 +169,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   talloc_set_destructor ((TALLOC_CTX *)csr, _sscg_csr_destructor);
 
   /* We will generate only x509v3 certificates */
-  sslret = X509_REQ_set_version (csr->x509_req, 2);
+  sslret = X509_REQ_set_version (csr->x509_req, X509_VERSION_1);
   CHECK_SSL (sslret, X509_REQ_set_version);
 
   subject = X509_REQ_get_subject_name (csr->x509_req);


### PR DESCRIPTION
RFC 2986 only defines a single version for CSRs: X509_VERSION_1 (0). OpenSSL starting with 3.4 rejects everything else.

Use X509_VERSION_1 as version for X509_REQ_set_version.

See openssl/openssl#20663