### PR TITLE
Minor include fixes

### DIFF
--- a/src/arguments.c
+++ b/src/arguments.c
@@ -30,7 +30,6 @@
     Copyright 2021-2023 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
-#include <path_utils.h>
 #include <popt.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -35,6 +35,7 @@
 #include <path_utils.h>
 #include <string.h>
 #include <talloc.h>
+#include <sys/stat.h>
 
 #include "include/io_utils.h"
 #include "include/key.h"

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <talloc.h>
-#include <path_utils.h>
 #include <unistd.h>
 #include <openssl/evp.h>
 #include <openssl/ssl.h>

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -41,6 +41,7 @@
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 #include <sys/param.h>
+#include <sys/stat.h>
 
 #include "config.h"
 #include "include/sscg.h"


### PR DESCRIPTION
- include needed headers for functions used explicitly
- drop `<path_utils.h>` where not needed