### PR TITLE
Fix Coverity-discovered issues with new tests

### DIFF
--- a/include/authority.h
+++ b/include/authority.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include "sscg.h"

--- a/include/authority.h
+++ b/include/authority.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/include/bignum.h
+++ b/include/bignum.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/include/bignum.h
+++ b/include/bignum.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #ifndef _SSCG_BIGNUM_H

--- a/include/cert.h
+++ b/include/cert.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include "sscg.h"

--- a/include/cert.h
+++ b/include/cert.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/include/dhparams.h
+++ b/include/dhparams.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/include/dhparams.h
+++ b/include/dhparams.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2019-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2019-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #ifndef _SSCG_DHPARAMS_H

--- a/include/io_utils.h
+++ b/include/io_utils.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2019-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2019-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #ifndef _SSCG_IO_UTILS_H

--- a/include/io_utils.h
+++ b/include/io_utils.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/include/key.h
+++ b/include/key.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/include/key.h
+++ b/include/key.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #ifndef _SSCG_KEY_H

--- a/include/sscg.h
+++ b/include/sscg.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/include/sscg.h
+++ b/include/sscg.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 /* This is a master header file that should be included by all

--- a/include/x509.h
+++ b/include/x509.h
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #ifndef _SSCG_X509_H

--- a/include/x509.h
+++ b/include/x509.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception
 # This file is part of sscg.
 #
 # sscg is free software: you can redistribute it and/or modify

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with sscg.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2019 by Stephen Gallagher <sgallagh@redhat.com>
+# Copyright 2019-2025 by Stephen Gallagher <sgallagh@redhat.com>
 
 # Generating 4096-bit Diffie-Hellman parameters can take over ten minutes on a
 # fast system. We skip testing it by default.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception
 # This file is part of sscg.
 #
 # sscg is free software: you can redistribute it and/or modify

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception
 # This file is part of sscg.
 #
 # sscg is free software: you can redistribute it and/or modify
@@ -12,6 +13,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with sscg.  If not, see <http://www.gnu.org/licenses/>.
+#
+# In addition, as a special exception, the copyright holders give
+# permission to link the code of portions of this program with the
+# OpenSSL library under certain conditions as described in each
+# individual source file, and distribute linked combinations
+# including the two.
+# You must obey the GNU General Public License in all respects
+# for all of the code used other than OpenSSL.  If you modify
+# file(s) with this exception, you may extend this exception to your
+# version of the file(s), but you are not obligated to do so.  If you
+# do not wish to do so, delete this exception statement from your
+# version.  If you delete this exception statement from all source
+# files in the program, then also delete it here.
 #
 # Copyright 2025 by Stephen Gallagher <sgallagh@redhat.com>
 

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception
 
 
 # This file is part of sscg.

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2021-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2021-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <popt.h>

--- a/src/authority.c
+++ b/src/authority.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <string.h>

--- a/src/authority.c
+++ b/src/authority.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/bignum.c
+++ b/src/bignum.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/bignum.c
+++ b/src/bignum.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <openssl/err.h>

--- a/src/cert.c
+++ b/src/cert.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/cert.c
+++ b/src/cert.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 

--- a/src/dhparams.c
+++ b/src/dhparams.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2019-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2019-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <assert.h>

--- a/src/dhparams.c
+++ b/src/dhparams.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2019-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2019-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/key.c
+++ b/src/key.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/key.c
+++ b/src/key.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <openssl/err.h>

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #define _GNU_SOURCE

--- a/src/sscg.c
+++ b/src/sscg.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <openssl/err.h>

--- a/test/create_ca_test.c
+++ b/test/create_ca_test.c
@@ -792,7 +792,8 @@ verify_name_constraints (struct sscg_x509_cert *ca_cert,
                           else
                             {
                               /* No netmask - add single host netmask */
-                              strcpy (clean_ip, expected_ip);
+                              strncpy (clean_ip, expected_ip, 64);
+                              clean_ip[63] = '\0';
 
                               if (strchr (clean_ip, ':'))
                                 {

--- a/test/create_ca_test.c
+++ b/test/create_ca_test.c
@@ -1055,44 +1055,33 @@ main (int argc, char **argv)
 
   /* Verify that subject alternative names were properly included */
   printf ("Verifying subject alternative names in service certificate. ");
-  int verify_ret = verify_subject_alt_names (cert);
-  if (verify_ret != EOK)
+  ret = verify_subject_alt_names (cert);
+  if (ret != EOK)
     {
       printf ("FAILED.\n");
-      ret = verify_ret; /* Store first failure but continue testing */
+      goto done;
     }
-  else
-    {
-      printf ("SUCCESS.\n");
-    }
+  printf ("SUCCESS.\n");
 
   /* Test additional SAN verification scenarios */
   printf ("Testing SAN edge cases and validation. ");
-  int edge_ret = test_san_edge_cases (cert);
-  if (edge_ret != EOK)
+  ret = test_san_edge_cases (cert);
+  if (ret != EOK)
     {
       printf ("FAILED.\n");
-      if (ret == EOK)
-        ret = edge_ret; /* Store first failure */
+      goto done;
     }
-  else
-    {
-      printf ("SUCCESS.\n");
-    }
+  printf ("SUCCESS.\n");
 
   /* Test IP address netmask handling */
   printf ("Testing IP address netmask stripping functionality. ");
-  int netmask_ret = test_ip_netmask_handling (cert);
-  if (netmask_ret != EOK)
+  ret = test_ip_netmask_handling (cert);
+  if (ret != EOK)
     {
       printf ("FAILED.\n");
-      if (ret == EOK)
-        ret = netmask_ret; /* Store first failure */
+      goto done;
     }
-  else
-    {
-      printf ("SUCCESS.\n");
-    }
+  printf ("SUCCESS.\n");
 
   /* ============= CA CERTIFICATE TESTS ============= */
 
@@ -1135,30 +1124,13 @@ main (int argc, char **argv)
 
   /* Verify name constraints in the CA certificate */
   printf ("Verifying name constraints in CA certificate. ");
-  int ca_constraints_ret =
-    verify_name_constraints (ca_cert, certinfo->subject_alt_names);
-  if (ca_constraints_ret != EOK)
+  ret = verify_name_constraints (ca_cert, certinfo->subject_alt_names);
+  if (ret != EOK)
     {
       printf ("FAILED.\n");
-      if (ret == EOK)
-        ret = ca_constraints_ret;
+      goto done;
     }
-  else
-    {
-      printf ("SUCCESS.\n");
-    }
-
-  /* Summary of all test results */
-  printf ("\n=== TEST SUMMARY ===\n");
-  printf ("Service cert SAN verification: %s\n",
-          verify_ret == EOK ? "PASS" : "FAIL");
-  printf ("Service cert edge case validation: %s\n",
-          edge_ret == EOK ? "PASS" : "FAIL");
-  printf ("Service cert netmask handling: %s\n",
-          netmask_ret == EOK ? "PASS" : "FAIL");
-  printf ("CA certificate creation: %s\n", ca_cert ? "PASS" : "FAIL");
-  printf ("CA name constraints verification: %s\n",
-          ca_constraints_ret == EOK ? "PASS" : "FAIL");
+  printf ("SUCCESS.\n");
 
 done:
   if (ret != EOK)

--- a/test/create_ca_test.c
+++ b/test/create_ca_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/create_ca_test.c
+++ b/test/create_ca_test.c
@@ -1125,6 +1125,13 @@ main (int argc, char **argv)
     {
       printf ("SUCCESS.\n");
     }
+  /* If create_private_CA returns EOK, ca_cert must be non-NULL */
+  if (ca_cert == NULL)
+    {
+      printf ("FAILED: ca_cert is NULL.\n");
+      ret = EINVAL;
+      goto done;
+    }
 
   /* Verify name constraints in the CA certificate */
   printf ("Verifying name constraints in CA certificate. ");

--- a/test/create_cert_test.c
+++ b/test/create_cert_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/create_csr_test.c
+++ b/test/create_csr_test.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <errno.h>

--- a/test/create_csr_test.c
+++ b/test/create_csr_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/dhparams_test.c
+++ b/test/dhparams_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/dhparams_test.c
+++ b/test/dhparams_test.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2019-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2019-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <errno.h>

--- a/test/generate_rsa_key_test.c
+++ b/test/generate_rsa_key_test.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <errno.h>

--- a/test/generate_rsa_key_test.c
+++ b/test/generate_rsa_key_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/generate_serial_test.c
+++ b/test/generate_serial_test.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <errno.h>

--- a/test/generate_serial_test.c
+++ b/test/generate_serial_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/init_bignum_test.c
+++ b/test/init_bignum_test.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2017-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2017-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <errno.h>

--- a/test/init_bignum_test.c
+++ b/test/init_bignum_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/named_dhparams_test.c
+++ b/test/named_dhparams_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception */
 /*
     This file is part of sscg.
 

--- a/test/named_dhparams_test.c
+++ b/test/named_dhparams_test.c
@@ -27,7 +27,7 @@
     version.  If you delete this exception statement from all source
     files in the program, then also delete it here.
 
-    Copyright 2019-2023 by Stephen Gallagher <sgallagh@redhat.com>
+    Copyright 2019-2025 by Stephen Gallagher <sgallagh@redhat.com>
 */
 
 #include <errno.h>

--- a/test/test_cert_validity.sh
+++ b/test/test_cert_validity.sh
@@ -29,7 +29,7 @@
 # version.  If you delete this exception statement from all source
 # files in the program, then also delete it here.
 #
-# Copyright 2022-2023 by Stephen Gallagher <sgallagh@redhat.com>
+# Copyright 2022-2025 by Stephen Gallagher <sgallagh@redhat.com>
 
 
 # ARG_OPTIONAL_SINGLE([hash-alg],[],[Certificate hashing algorithm],[sha256])

--- a/test/test_cert_validity.sh
+++ b/test/test_cert_validity.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later WITH cryptsetup-OpenSSL-exception
 
 
 # This file is part of sscg.


### PR DESCRIPTION
## Simplify create_ca_test

Failures are now immediate, rather than accumulated.

Resolves: Coverity 1647710

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

## Test: Verify that ca_cert is always non-NULL

If create_private_CA() returns EOK, ca_cert must always be non-NULL.

Resolves: Coverity 1648023

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

## test: Avoid possible buffer overflow

Resolves: Coverity #1648024

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>