### PR TITLE
Adapt to OpenSSL 4

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,6 @@ RUN dnf update -y && \
         openssl-devel \
         libtalloc-devel \
         popt-devel \
-        libpath_utils-devel \
         # Internationalization
         gettext-devel \
         # Documentation

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,8 +8,8 @@ This devcontainer provides a complete development environment for the SSCG proje
 - **Container Runtime**: Optimized for Podman (also works with Docker)
 - **Build System**: Meson + Ninja
 - **Compiler**: GCC with C17 support
-- **Dependencies**: All required libraries (OpenSSL 3.0+, talloc, popt, path_utils)
-- **Development Tools**: 
+- **Dependencies**: All required libraries (OpenSSL 3.0+, talloc, popt)
+- **Development Tools**:
   - clang-format for code formatting
   - GDB and Valgrind for debugging
   - Git, vim, nano for development
@@ -32,7 +32,7 @@ This devcontainer provides a complete development environment for the SSCG proje
    ```bash
    # Fedora/RHEL/CentOS
    sudo dnf install podman podman-docker
-   
+
    # Ubuntu/Debian
    sudo apt install podman podman-docker
    ```
@@ -146,7 +146,7 @@ gcc --version
 meson --version
 
 # Check dependencies
-pkg-config --exists openssl talloc popt path_utils && echo "All dependencies found"
+pkg-config --exists openssl talloc popt && echo "All dependencies found"
 
 # Build and test
 meson setup test_build

--- a/.devcontainer/test-setup.sh
+++ b/.devcontainer/test-setup.sh
@@ -35,9 +35,6 @@ pkg-config --exists talloc && echo "✓ Found" || echo "✗ Missing"
 echo -n "popt: "
 pkg-config --exists popt && echo "✓ Found" || echo "✗ Missing"
 
-echo -n "path_utils: "
-pkg-config --exists path_utils && echo "✓ Found" || echo "✗ Missing"
-
 echo -n "gettext: "
 pkg-config --exists intl && echo "✓ Found" || echo "⚠ Optional (not found)"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,56 +18,56 @@ jobs:
           - clang
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Install build dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y build-essential meson pkgconf openssl libssl-dev libpath-utils-dev libtalloc-dev help2man libpopt-dev ${{ matrix.compiler }}
-        sudo apt install -y --no-install-recommends debhelper devscripts lintian
-        # 18.04's debhelper is too old, we want to use compat level 12
-        if grep -q 18.04 /etc/os-release; then
-            sudo apt install -y -t bionic-backports debhelper
-        fi
+      - name: Install build dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential meson pkgconf openssl libssl-dev libpath-utils-dev libtalloc-dev help2man libpopt-dev ${{ matrix.compiler }}
+          sudo apt install -y --no-install-recommends debhelper devscripts lintian
+          # 18.04's debhelper is too old, we want to use compat level 12
+          if grep -q 18.04 /etc/os-release; then
+              sudo apt install -y -t bionic-backports debhelper
+          fi
 
-    - name: Configure build directory
-      run: |
-        CC=${{ matrix.compiler}} meson setup ${{ matrix.os }}
+      - name: Configure build directory
+        run: |
+          CC=${{ matrix.compiler}} meson setup ${{ matrix.os }}
 
-    - name: Build SSCG
-      run: |
-        ninja -C ${{ matrix.os }}
+      - name: Build SSCG
+        run: |
+          ninja -C ${{ matrix.os }}
 
-    - name: Run in-tree tests
-      run: |
-        meson test -t 5 --print-errorlogs -C ${{ matrix.os }}
+      - name: Run in-tree tests
+        run: |
+          meson test -t 5 --print-errorlogs -C ${{ matrix.os }}
 
-    - name: Build Debian source package
-      run: |
-        set -ex
-        mkdir deb
-        # keep version number as 0 for upstream, to match debian/changelog
-        git archive -o deb/sscg_0.orig.tar.gz --prefix sscg/ HEAD
-        cd deb
-        # unpack tar again to make sure the dist is complete and clean
-        tar xf sscg_*.tar.gz
-        cd sscg
-        cp -r packaging/debian .
+      - name: Build Debian source package
+        run: |
+          set -ex
+          mkdir deb
+          # keep version number as 0 for upstream, to match debian/changelog
+          git archive -o deb/sscg_0.orig.tar.gz --prefix sscg/ HEAD
+          cd deb
+          # unpack tar again to make sure the dist is complete and clean
+          tar xf sscg_*.tar.gz
+          cd sscg
+          cp -r packaging/debian .
 
-        # build source and binary package, with lintian
-        debuild -e CC=${{ matrix.compiler}} -us -uc
+          # build source and binary package, with lintian
+          debuild -e CC=${{ matrix.compiler}} -us -uc
 
-    - name: Install built Debian binary package
-      run: |
-        sudo dpkg -i deb/sscg_*.deb
+      - name: Install built Debian binary package
+        run: |
+          sudo dpkg -i deb/sscg_*.deb
 
-    - name: Smoke test installed package
-      run: |
-        cd /tmp/
-        sscg
-        openssl x509 -in service.pem -text
-        openssl x509 -in ca.crt -text
+      - name: Smoke test installed package
+        run: |
+          cd /tmp/
+          sscg
+          openssl x509 -in service.pem -text
+          openssl x509 -in ca.crt -text
 
   get_fedora_releases:
     name: Get Fedora Releases
@@ -98,38 +98,37 @@ jobs:
       options: --security-opt seccomp=unconfined
 
     steps:
-    - name: Identify the system
-      run: |
-        cat /etc/os-release
+      - name: Identify the system
+        run: |
+          cat /etc/os-release
 
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Install build dependencies
-      run: |
-        dnf install -y meson util-linux pkgconf openssl openssl-devel libpath_utils-devel libtalloc-devel help2man popt-devel ${{ matrix.compiler }}
+      - name: Install build dependencies
+        run: |
+          dnf install -y meson util-linux pkgconf openssl openssl-devel libtalloc-devel help2man popt-devel ${{ matrix.compiler }}
 
-    - name: Create user
-      run: |
-        useradd -m -s /bin/bash -G wheel sscg
-        tail /etc/passwd
+      - name: Create user
+        run: |
+          useradd -m -s /bin/bash -G wheel sscg
+          tail /etc/passwd
 
-    - name: Make checkout directory editable by the sscg user
-      run: |
-        chown -R sscg:wheel ${GITHUB_WORKSPACE}
+      - name: Make checkout directory editable by the sscg user
+        run: |
+          chown -R sscg:wheel ${GITHUB_WORKSPACE}
 
-    - name: Configure build directory
-      run: |
-        CC=${{ matrix.compiler}} su -c "meson setup fedora-${{ matrix.release }}" sscg
+      - name: Configure build directory
+        run: |
+          CC=${{ matrix.compiler}} su -c "meson setup fedora-${{ matrix.release }}" sscg
 
-    - name: Build SSCG
-      run: |
-        su -c "ninja -C fedora-${{ matrix.release }}" sscg
+      - name: Build SSCG
+        run: |
+          su -c "ninja -C fedora-${{ matrix.release }}" sscg
 
-    - name: Run in-tree tests
-      run: |
-        su -c "meson test -t 5 --print-errorlogs -C fedora-${{ matrix.release }}" sscg
-
+      - name: Run in-tree tests
+        run: |
+          su -c "meson test -t 5 --print-errorlogs -C fedora-${{ matrix.release }}" sscg
 
   centos-stream:
     name: CentOS Stream x86_64
@@ -151,46 +150,45 @@ jobs:
       options: --security-opt seccomp=unconfined
 
     steps:
-    - name: Identify the system
-      run: |
-        cat /etc/os-release
+      - name: Identify the system
+        run: |
+          cat /etc/os-release
 
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Enable DNF tools
-      run: |
-        yum -y install dnf-plugins-core
+      - name: Enable DNF tools
+        run: |
+          yum -y install dnf-plugins-core
 
-    - name: Enable CRB
-      run: |
-        yum config-manager --set-enabled crb
+      - name: Enable CRB
+        run: |
+          yum config-manager --set-enabled crb
 
-    - name: Install build dependencies
-      run: |
-        yum install -y meson util-linux pkgconf-pkg-config openssl openssl-devel libpath_utils-devel libtalloc-devel help2man popt-devel ${{ matrix.compiler }}
+      - name: Install build dependencies
+        run: |
+          yum install -y meson util-linux pkgconf-pkg-config openssl openssl-devel libtalloc-devel help2man popt-devel ${{ matrix.compiler }}
 
-    - name: Create user
-      run: |
-        useradd -m -s /bin/bash -G wheel sscg
-        tail /etc/passwd
+      - name: Create user
+        run: |
+          useradd -m -s /bin/bash -G wheel sscg
+          tail /etc/passwd
 
-    - name: Make checkout directory editable by the sscg user
-      run: |
-        chown -R sscg:wheel ${GITHUB_WORKSPACE}
+      - name: Make checkout directory editable by the sscg user
+        run: |
+          chown -R sscg:wheel ${GITHUB_WORKSPACE}
 
-    - name: Configure build directory
-      run: |
-        CC=${{ matrix.compiler}} su -c "meson setup --errorlogs centos-stream-${{ matrix.release }}" sscg || ( cat centos-stream-${{ matrix.release }}/meson-logs/meson-log.txt && exit 1 )
+      - name: Configure build directory
+        run: |
+          CC=${{ matrix.compiler}} su -c "meson setup --errorlogs centos-stream-${{ matrix.release }}" sscg || ( cat centos-stream-${{ matrix.release }}/meson-logs/meson-log.txt && exit 1 )
 
-    - name: Build SSCG
-      run: |
-        su -c "ninja -C centos-stream-${{ matrix.release }}" sscg
+      - name: Build SSCG
+        run: |
+          su -c "ninja -C centos-stream-${{ matrix.release }}" sscg
 
-    - name: Run in-tree tests
-      run: |
-        su -c "meson test -t 5 --print-errorlogs -C centos-stream-${{ matrix.release }}" sscg
-
+      - name: Run in-tree tests
+        run: |
+          su -c "meson test -t 5 --print-errorlogs -C centos-stream-${{ matrix.release }}" sscg
 
   fedora-eln:
     name: Fedora ELN x86_64
@@ -207,34 +205,34 @@ jobs:
       options: --security-opt seccomp=unconfined
 
     steps:
-    - name: Identify the system
-      run: |
-        cat /etc/os-release
+      - name: Identify the system
+        run: |
+          cat /etc/os-release
 
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Install build dependencies
-      run: |
-        dnf install -y meson util-linux pkgconf openssl openssl-devel libpath_utils-devel libtalloc-devel help2man popt-devel shadow-utils ${{ matrix.compiler }}
+      - name: Install build dependencies
+        run: |
+          dnf install -y meson util-linux pkgconf openssl openssl-devel libtalloc-devel help2man popt-devel shadow-utils ${{ matrix.compiler }}
 
-    - name: Create user
-      run: |
-        useradd -m -s /bin/bash -G wheel sscg
-        tail /etc/passwd
+      - name: Create user
+        run: |
+          useradd -m -s /bin/bash -G wheel sscg
+          tail /etc/passwd
 
-    - name: Make checkout directory editable by the sscg user
-      run: |
-        chown -R sscg:wheel ${GITHUB_WORKSPACE}
+      - name: Make checkout directory editable by the sscg user
+        run: |
+          chown -R sscg:wheel ${GITHUB_WORKSPACE}
 
-    - name: Configure build directory
-      run: |
-        CC=${{ matrix.compiler}} su -c "meson setup fedora-eln" sscg
+      - name: Configure build directory
+        run: |
+          CC=${{ matrix.compiler}} su -c "meson setup fedora-eln" sscg
 
-    - name: Build SSCG
-      run: |
-        su -c "ninja -C fedora-eln" sscg
+      - name: Build SSCG
+        run: |
+          su -c "ninja -C fedora-eln" sscg
 
-    - name: Run in-tree tests
-      run: |
-        su -c "meson test -t 5 --print-errorlogs -C fedora-eln" sscg
+      - name: Run in-tree tests
+        run: |
+          su -c "meson test -t 5 --print-errorlogs -C fedora-eln" sscg

--- a/.github/workflows/upstreamed.yaml
+++ b/.github/workflows/upstreamed.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - upstreamed  # For testing changes to this file
+      - upstreamed # For testing changes to this file
 
 jobs:
   coverity:
@@ -15,45 +15,46 @@ jobs:
       image: quay.io/centos/centos:stream9
 
     steps:
-    - name: Install git
-      run: |
-        yum -y install git-core
+      - name: Install git
+        run: |
+          yum -y install git-core
 
-    - name: Checkout Code
-      uses: actions/checkout@v6
+      - name: Checkout Code
+        uses: actions/checkout@v6
 
-    - name: Work around dubious ownership bug (https://github.com/actions/checkout/issues/1169)
-      run: |
-        git config --system --add safe.directory $GITHUB_WORKSPACE
+      - name: Work around dubious ownership bug
+          (https://github.com/actions/checkout/issues/1169)
+        run: |
+          git config --system --add safe.directory $GITHUB_WORKSPACE
 
-    - name: Enable EPEL
-      run: |
-        yum -y install epel-release
+      - name: Enable EPEL
+        run: |
+          yum -y install epel-release
 
-    - name: Enable CRB
-      run: |
-        yum -y install dnf-plugins-core
-        yum config-manager --set-enabled crb
+      - name: Enable CRB
+        run: |
+          yum -y install dnf-plugins-core
+          yum config-manager --set-enabled crb
 
-    - name: Install build dependencies
-      run: |
-        yum install -y clang help2man meson gcc ninja-build wget openssl popt-devel sudo pkgconfig redhat-rpm-config ruby rubygems "rubygem(json)" libtalloc-devel libpath_utils-devel openssl-devel
+      - name: Install build dependencies
+        run: |
+          yum install -y clang help2man meson gcc ninja-build wget openssl popt-devel sudo pkgconfig redhat-rpm-config ruby rubygems "rubygem(json)" libtalloc-devel openssl-devel
 
-    - name: Set Up Coverity Scanner
-      run: |
-        .ci/coverity_prep.sh
+      - name: Set Up Coverity Scanner
+        run: |
+          .ci/coverity_prep.sh
 
-    - name: Configure build directory
-      run: |
-        CC=gcc meson --errorlogs -Drun_slow_tests=true coverity
+      - name: Configure build directory
+        run: |
+          CC=gcc meson --errorlogs -Drun_slow_tests=true coverity
 
-    - name: Perform Coverity Scan Build
-      env:
-        TRAVIS_BRANCH: ${{ github.ref }}
-        COVERITY_SCAN_PROJECT_NAME: sgallagher/sscg
-        COVERITY_SCAN_NOTIFICATION_EMAIL: sgallagh@redhat.com
-        COVERITY_SCAN_BRANCH_PATTERN: .*main
-        COVERITY_SCAN_BUILD_COMMAND: ninja -C coverity
-        COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_TOKEN }}
-      run: |
-         /usr/bin/travisci_build_coverity_scan.sh ||: 
+      - name: Perform Coverity Scan Build
+        env:
+          TRAVIS_BRANCH: ${{ github.ref }}
+          COVERITY_SCAN_PROJECT_NAME: sgallagher/sscg
+          COVERITY_SCAN_NOTIFICATION_EMAIL: sgallagh@redhat.com
+          COVERITY_SCAN_BRANCH_PATTERN: .*main
+          COVERITY_SCAN_BUILD_COMMAND: ninja -C coverity
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+        run: |
+          /usr/bin/travisci_build_coverity_scan.sh ||:

--- a/include/x509.h
+++ b/include/x509.h
@@ -70,6 +70,11 @@ struct sscg_x509_req
   X509_REQ *x509_req;
 };
 
+struct sscg_x509_name
+{
+  X509_NAME *name;
+};
+
 struct sscg_x509_cert
 {
   X509 *certificate;

--- a/src/x509.c
+++ b/src/x509.c
@@ -135,6 +135,17 @@ _sscg_csr_destructor (TALLOC_CTX *ctx)
   return 0;
 }
 
+static int
+_sscg_x509_name_destructor (TALLOC_CTX *ctx)
+{
+  struct sscg_x509_name *subject_name =
+    talloc_get_type_abort (ctx, struct sscg_x509_name);
+
+  X509_NAME_free (subject_name->name);
+
+  return 0;
+}
+
 int
 sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
                      struct sscg_cert_info *certinfo,
@@ -143,7 +154,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
 {
   int ret, sslret;
   size_t i;
-  X509_NAME *subject;
+  struct sscg_x509_name *subject = NULL;
   char *alt_name = NULL;
   char *tmp = NULL;
   char *san = NULL;
@@ -173,11 +184,16 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   sslret = X509_REQ_set_version (csr->x509_req, 0);
   CHECK_SSL (sslret, X509_REQ_set_version);
 
-  subject = X509_REQ_get_subject_name (csr->x509_req);
+  subject = talloc_zero (tmp_ctx, struct sscg_x509_name);
+  CHECK_MEM (subject);
+
+  subject->name = X509_NAME_new ();
+  CHECK_MEM (subject->name);
+  talloc_set_destructor ((TALLOC_CTX *)subject, _sscg_x509_name_destructor);
 
   /* Country */
   sslret =
-    X509_NAME_add_entry_by_NID (subject,
+    X509_NAME_add_entry_by_NID (subject->name,
                                 NID_countryName,
                                 MBSTRING_UTF8,
                                 (const unsigned char *)certinfo->country,
@@ -190,7 +206,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   if (certinfo->state && certinfo->state[0])
     {
       sslret =
-        X509_NAME_add_entry_by_NID (subject,
+        X509_NAME_add_entry_by_NID (subject->name,
                                     NID_stateOrProvinceName,
                                     MBSTRING_UTF8,
                                     (const unsigned char *)certinfo->state,
@@ -204,7 +220,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   if (certinfo->locality && certinfo->locality[0])
     {
       sslret =
-        X509_NAME_add_entry_by_NID (subject,
+        X509_NAME_add_entry_by_NID (subject->name,
                                     NID_localityName,
                                     MBSTRING_UTF8,
                                     (const unsigned char *)certinfo->locality,
@@ -218,7 +234,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   if (certinfo->org && certinfo->org[0])
     {
       sslret =
-        X509_NAME_add_entry_by_NID (subject,
+        X509_NAME_add_entry_by_NID (subject->name,
                                     NID_organizationName,
                                     MBSTRING_UTF8,
                                     (const unsigned char *)certinfo->org,
@@ -232,7 +248,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   if (certinfo->org_unit && certinfo->org_unit[0])
     {
       sslret =
-        X509_NAME_add_entry_by_NID (subject,
+        X509_NAME_add_entry_by_NID (subject->name,
                                     NID_organizationalUnitName,
                                     MBSTRING_UTF8,
                                     (const unsigned char *)certinfo->org_unit,
@@ -243,7 +259,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
     }
 
   /* Common Name */
-  sslret = X509_NAME_add_entry_by_NID (subject,
+  sslret = X509_NAME_add_entry_by_NID (subject->name,
                                        NID_commonName,
                                        MBSTRING_UTF8,
                                        (const unsigned char *)certinfo->cn,
@@ -256,7 +272,7 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
   if (certinfo->email && certinfo->email[0])
     {
       sslret =
-        X509_NAME_add_entry_by_NID (subject,
+        X509_NAME_add_entry_by_NID (subject->name,
                                     NID_pkcs9_emailAddress,
                                     MBSTRING_UTF8,
                                     (const unsigned char *)certinfo->email,
@@ -265,6 +281,9 @@ sscg_x509v3_csr_new (TALLOC_CTX *mem_ctx,
                                     0);
       CHECK_SSL (sslret, X509_NAME_add_entry_by_NID (Email));
     }
+
+  sslret = X509_REQ_set_subject_name (csr->x509_req, subject->name);
+  CHECK_SSL (sslret, X509_REQ_set_subject_name);
 
   /* SubjectAltNames */
   alt_name = talloc_asprintf (tmp_ctx, "DNS:%s", certinfo->cn);

--- a/test/create_ca_test.c
+++ b/test/create_ca_test.c
@@ -567,8 +567,8 @@ verify_name_constraints (struct sscg_x509_cert *ca_cert,
   int ret = EOK;
   TALLOC_CTX *tmp_ctx = NULL;
   X509 *x509 = ca_cert->certificate;
-  X509_EXTENSION *name_constraints_ext = NULL;
-  ASN1_OCTET_STRING *ext_data = NULL;
+  const X509_EXTENSION *name_constraints_ext = NULL;
+  const ASN1_OCTET_STRING *ext_data = NULL;
   BIO *bio = NULL;
   char *ext_str = NULL;
   char *ext_str_copy = NULL;

--- a/test/create_cert_test.c
+++ b/test/create_cert_test.c
@@ -51,8 +51,8 @@ verify_name_constraints (struct sscg_x509_cert *ca_cert,
   int ret = EOK;
   TALLOC_CTX *tmp_ctx = NULL;
   X509 *x509 = ca_cert->certificate;
-  X509_EXTENSION *name_constraints_ext = NULL;
-  ASN1_OCTET_STRING *ext_data = NULL;
+  const X509_EXTENSION *name_constraints_ext = NULL;
+  const ASN1_OCTET_STRING *ext_data = NULL;
   BIO *bio = NULL;
   char *ext_str = NULL;
   int ext_len = 0;


### PR DESCRIPTION
OpenSSL returns const pointers for some functions that were previously non-const. This also revealed that it was probably a bad idea to be modifying the CSR subject name in-place, so we now create a completely new X509_NAME object, populate it and then store it into the CSR.